### PR TITLE
Improve bot help and LAN deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,5 +71,4 @@ RUN pip install *.whl
 
 WORKDIR /app
 
-
-# CMD ["/docker-entrypoint.sh"]
+CMD ["python", "-u", "-m", "actual_discord_bot.bot"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ an existing receipt.
 - **Split transactions** — Each product line item becomes a sub-transaction in Actual Budget
 - **Discount handling** — Recognizes OBNIŻKA/RABAT/UPUST discount lines and includes them as negative sub-transactions
 - **Idempotent catch-up** — `!catch_up` command processes all unprocessed messages in the channel (skips already-reacted ones)
+- **In-channel guidance** — Posts a complete usage guide on startup and provides it on demand with `!help`
 - **Hot-reload** — Uses [cogwatch](https://github.com/robertwayne/cogwatch) for live code reloading during development
 - **Dockerized deployment** — Full Docker Compose setup with bot, Actual server, and integration test services
 
@@ -82,51 +83,164 @@ actual_discord_bot/
     └── transaction.py      # Split transaction creation & deduplication
 ```
 
-## Installation
+## Home LAN Deployment
+
+This is the recommended real-life setup: one always-on Linux machine on your home
+LAN runs Actual Server and the Discord bot with Docker Compose. Phones and
+computers on the same LAN open Actual using that machine's private IP address.
+This guide deliberately does not expose Actual to the internet or cover domains,
+DNS, TLS, VPNs, or cloud hosting.
 
 ### Prerequisites
 
-- Python 3.13+
-- [Poetry](https://python-poetry.org/docs/#installation) (v1.8+)
-- [Actual Budget server](https://actualbudget.org/docs/install/docker) instance
-- A Discord bot token ([guide](https://discord.com/developers/docs/getting-started))
+- An always-on Linux machine connected to the home router by Ethernet or Wi-Fi
+- Docker Engine with the Compose plugin (`docker compose version` must work)
+- A static DHCP lease for the Linux machine, recommended so its LAN IP does not change
+- A Discord account and a server where you can create channels and invite a bot
+- An Android phone if bank notifications will be forwarded with Automate
 
-### Using Docker (recommended)
+### 1. Prepare the Linux host
 
 ```bash
-# Clone the repository
 git clone https://github.com/MariuszBielecki288728/actual-discord-bot.git
 cd actual-discord-bot
-
-# Create .env file (see Configuration section)
-cp .env.example .env  # edit with your values
-
-# Start the bot and Actual server
-docker-compose up bot
+cp deployment/lan/.env.example deployment/lan/.env
+hostname -I
 ```
 
-### Local Development
+Record the private address printed by the last command, for example
+`192.168.1.50`. Reserve that address for this machine in the router's DHCP
+settings if possible. Port `12012` must be allowed by the Linux firewall for the
+local subnet, but should not be forwarded on the router.
+
+### 2. Start and configure Actual Server
+
+Start only Actual first:
 
 ```bash
-# Create virtual env
+docker compose --env-file deployment/lan/.env \
+  -f deployment/lan/compose.yml up -d actual_server
+```
+
+On a device in the same LAN, open `http://192.168.1.50:12012`, substituting the
+host IP. Complete Actual's first-run setup, set a strong server password, and
+create or upload the budget that the bot will use. Create an account for imported
+transactions—for example `Pekao`.
+
+Edit `deployment/lan/.env`:
+
+- `ACTUAL_PASSWORD` is the Actual server password.
+- `ACTUAL_FILE` is the budget file name shown in Actual (for example `My Finances`).
+- `ACTUAL_ENCRYPTION_PASSWORD` is only needed if that budget uses end-to-end encryption.
+- `ACTUAL_ACCOUNT` must exactly match the destination account name in the budget.
+
+The Actual mobile experience is the same web application: connect the phone to
+home Wi-Fi and open `http://192.168.1.50:12012`. Add it to the home screen if
+desired. This address is intentionally available only while connected to the LAN.
+
+### 3. Create and invite the Discord bot
+
+1. In the Discord Developer Portal, create an application and add a bot.
+2. On the bot page, enable the privileged **Message Content Intent**. The bot
+   needs it to read forwarded notifications and commands.
+3. Copy the bot token into `DISCORD_TOKEN` in `deployment/lan/.env`. Treat it like
+   a password and never commit the `.env` file.
+4. In the OAuth2 URL Generator, select the `bot` scope and grant **View Channels**,
+   **Send Messages**, **Read Message History**, **Add Reactions**, and
+   **Attach Files**. Open the generated URL and invite the bot to your server.
+5. Create `bank-notifications` and, optionally, `receipts` text channels. Give the
+   bot the permissions above in both. If different names are used, put the exact
+   names (without `#`) in `DISCORD_BANK_NOTIFICATION_CHANNEL` and
+   `DISCORD_RECEIPT_CHANNEL`.
+
+### 4. Forward bank notifications
+
+Create an incoming Discord webhook for the bank notification channel and copy its
+URL. In Android Automate, build a flow that waits for notifications from the bank
+app and sends an HTTP POST to that webhook with a JSON body whose `content` is:
+
+```text
+Title: <notification title>
+Text: <notification body>
+Timestamp: <notification timestamp>
+```
+
+Set the request content type to `application/json`. Restrict the flow to the bank
+app's package so unrelated phone notifications are never uploaded. The parser
+currently supports Bank Pekao notification wording; test with one notification
+and confirm the transaction in Actual before leaving the flow enabled.
+
+### 5. Start the complete stack
+
+Finish editing `deployment/lan/.env`, then run:
+
+```bash
+docker compose --env-file deployment/lan/.env \
+  -f deployment/lan/compose.yml up -d --build
+docker compose -f deployment/lan/compose.yml logs -f bot
+```
+
+When connected, the bot posts its usage guide in every configured channel. Send
+`!help` to retrieve it later. Post a receipt in the receipt channel or forward a
+test bank message, then verify both the Discord response and the transaction in
+Actual.
+
+Useful operating commands:
+
+```bash
+# Status and logs
+docker compose -f deployment/lan/compose.yml ps
+docker compose -f deployment/lan/compose.yml logs --tail=100 bot actual_server
+
+# Pull code and rebuild the bot
+git pull
+docker compose --env-file deployment/lan/.env \
+  -f deployment/lan/compose.yml up -d --build
+
+# Stop services without deleting budget data
+docker compose -f deployment/lan/compose.yml down
+```
+
+Actual data lives in the named Docker volume `actual-budget-home_actual_data`.
+Back it up regularly. Do not run `docker compose down -v` unless you intend to
+delete that volume. A backup should be tested before relying on it.
+
+### Troubleshooting
+
+- No startup message: check `docker compose ... logs bot`, channel spelling, bot
+  permissions, Message Content Intent, and the token.
+- Actual cannot be opened from a phone: confirm both devices are on the same LAN,
+  use the Linux host's IP rather than `localhost`, and check the host firewall.
+- Actual connection errors in bot logs: verify password, budget name, account
+  name, and encryption password. Inside Compose the bot correctly uses
+  `http://actual_server:5006`; do not replace it with the host's LAN IP.
+- A bank message has no ✅: its format or wording was not recognized. Inspect the
+  logs, then use `!catch_up` after correcting the cause.
+- OCR results are wrong: use a sharp, evenly lit, straight-on photo and verify the
+  resulting split transaction manually.
+
+## Development Installation
+
+For modifying or testing the project locally, install Python 3.13 and Poetry:
+
+```bash
 python3.13 -m venv ./venv
 source ./venv/bin/activate
-
-# Install Poetry (if not already in venv)
 pip install poetry
-
-# Install all dependencies
 poetry install --with dev,linters,tests
-
-# Install pre-commit hooks
 pre-commit install
 ```
 
-> **Note:** Poetry is installed inside the venv. Always run `source ./venv/bin/activate` before using `poetry`, `pytest`, `pre-commit`, or any other project tooling.
+> Poetry and project tooling live inside the venv. Activate it before running
+> `poetry`, `pytest`, or `pre-commit`.
 
-## Configuration
+The root `docker-compose.yml` supports development and integration testing. For a
+real installation, prefer the isolated `deployment/lan/compose.yml` described
+above.
 
-The bot is configured via environment variables. Create a `.env` file in the project root:
+## Configuration Reference
+
+The bot is configured with these environment variables:
 
 ```bash
 # Discord
@@ -135,7 +249,7 @@ DISCORD_BANK_NOTIFICATION_CHANNEL=bank-notifications  # channel name (not ID)
 DISCORD_RECEIPT_CHANNEL=receipts                      # optional: channel for receipt photos/PDFs
 
 # Actual Budget
-ACTUAL_URL=http://localhost:5006        # URL of your Actual server
+ACTUAL_URL=http://actual_server:5006    # Compose service URL used by the bot
 ACTUAL_PASSWORD=your_actual_password    # Actual server password
 ACTUAL_FILE=My Budget                   # Budget file name or ID
 ACTUAL_ENCRYPTION_PASSWORD=             # Optional: E2E encryption password
@@ -163,11 +277,11 @@ OCR_TESSERACT_PSM=6                     # Tesseract page segmentation mode (defa
 
 ## Usage
 
-### Running the bot
+### Running the development stack
 
 ```bash
 # Via Docker (recommended)
-docker-compose up bot
+docker compose up bot
 
 # Or directly
 python -m actual_discord_bot.bot
@@ -177,6 +291,7 @@ python -m actual_discord_bot.bot
 
 | Command | Description |
 |---------|-------------|
+| `!help` | Show the full channel guide, reactions, supported inputs, and commands |
 | `!catch_up` | Process all unprocessed messages in the notification channel |
 
 ### Discord Channel Setup
@@ -184,7 +299,7 @@ python -m actual_discord_bot.bot
 1. Create a text channel (e.g., `bank-notifications`) in your Discord server
 2. Set up the Automate app on your Android phone to forward bank notifications to this channel
 3. (Optional) Create a second channel (e.g., `receipts`) for posting receipt photos and PDF receipts
-4. The bot will automatically process new messages and create transactions
+4. The bot posts its usage guide on startup and automatically processes new messages
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ docker compose --env-file deployment/lan/.env \
 docker compose -f deployment/lan/compose.yml logs -f bot
 ```
 
-When connected, the bot posts its usage guide in every configured channel. Send
-`!help` to retrieve it later. Post a receipt in the receipt channel or forward a
-test bank message, then verify both the Discord response and the transaction in
-Actual.
+When connected, the bot posts a friendly, channel-specific guide in every
+configured channel. Send `!help` to retrieve the appropriate guide later. Post a
+receipt in the receipt channel or forward a test bank message, then verify both
+the Discord response and the transaction in Actual.
 
 Useful operating commands:
 

--- a/actual_discord_bot/bot.py
+++ b/actual_discord_bot/bot.py
@@ -22,27 +22,33 @@ REACTION_WARNING = "⚠️"
 MAX_ITEMS_IN_SUMMARY = 5
 MAX_RECEIPT_ATTACHMENT_BYTES = 10 * 1024 * 1024
 
-HELP_MESSAGE = """**Actual Budget bot — channel guide**
+NOTIFICATION_HELP_MESSAGE = """👋 **Hello! I am your Actual Budget notification assistant.**
 
-I turn messages in the configured bank-notification channel into Actual Budget transactions. Currently I understand Bank Pekao card payments, incoming and outgoing transfers, and phone top-ups forwarded in this format:
+I watch this channel for bank notifications and turn them into transactions in Actual Budget. Currently I understand Bank Pekao card payments, incoming and outgoing transfers, and phone top-ups forwarded in this format:
 ```
 Title: <notification title>
 Text: <notification text>
 Timestamp: <timestamp>
 ```
-A ✅ means the transaction was saved. A message without ✅ was not imported; check the bot logs, correct the message if needed, and run `!catch_up`.
+A ✅ means the transaction was saved. A message without ✅ was not imported; check the bot logs, correct the cause if needed, and run `!catch_up`.
 
-In the configured receipts channel, attach one JPG, JPEG, PNG, WebP, or PDF receipt (maximum 10 MB). I extract the merchant, date, total, and items, then create one split transaction. I reply with the result and react with ✅ when created, ⚠️ for a duplicate or totals mismatch, and ❌ when processing fails. Receipt OCR is best-effort, so verify imported transactions in Actual Budget.
+**How notifications reach this channel**
+An administrator can create a Discord webhook for this channel in **Edit Channel → Integrations → Webhooks**. Its webhook URL is the special link that can post messages here—keep it private. On Android, an Automate flow can listen only for notifications from your bank app and send an HTTP POST to that URL, using `application/json` and the format above in the JSON `content` field. Never put your Discord bot token or Actual password in the flow or channel.
 
 **Commands**
-`!help` — show this guide
-`!catch_up` — retry every bank-channel message that does not already have my ✅
+`!help` — show this notification guide
+`!catch_up` — retry messages in this channel that do not already have my ✅"""
 
-Commands may be sent in either configured channel. I ignore other text in the receipts channel and unsupported attachments. Never post Actual or Discord passwords in a channel."""
+RECEIPT_HELP_MESSAGE = """👋 **Hello! I am your Actual Budget receipt assistant.**
 
-STARTUP_MESSAGE = (
-    "I am online and watching this channel. Here is how to use me:\n\n" + HELP_MESSAGE
-)
+Attach one JPG, JPEG, PNG, WebP, or PDF receipt to this channel (maximum 10 MB). I extract the merchant, date, total, and product lines, then create one split transaction in Actual Budget.
+
+I react with ✅ and reply with a summary when a transaction is created. ⚠️ means I found a likely duplicate or the extracted item totals did not match the receipt total, so nothing was saved. ❌ means processing failed. Image text is read with OCR and may be imperfect; use a sharp, evenly lit, straight-on photo and always verify the result in Actual Budget. I ignore ordinary text and unsupported attachments.
+
+**Command**
+`!help` — show this receipt guide
+
+Receipts may contain sensitive information, so only post them in a private channel that is visible to people you trust."""
 
 
 class ActualDiscordBot(commands.Bot):
@@ -89,19 +95,17 @@ class ActualDiscordBot(commands.Bot):
 
     async def _send_startup_help(self) -> None:
         """Announce the bot once per process in every configured channel found."""
-        channels = {channel.id: channel for channel in self._followed_channels()}
-        for channel in channels.values():
+        channel_guides = (
+            (self.target_channel, NOTIFICATION_HELP_MESSAGE),
+            (self.receipt_target_channel, RECEIPT_HELP_MESSAGE),
+        )
+        for channel, guide in channel_guides:
+            if channel is None:
+                continue
             try:
-                await channel.send(STARTUP_MESSAGE)
+                await channel.send(guide)
             except (discord.Forbidden, discord.HTTPException) as error:
                 print(f"Could not send startup help to '{channel.name}': {error}")
-
-    def _followed_channels(self) -> tuple[discord.TextChannel, ...]:
-        return tuple(
-            channel
-            for channel in (self.target_channel, self.receipt_target_channel)
-            if channel is not None
-        )
 
     async def create_actual_transaction(self, message: discord.Message) -> bool:
         try:
@@ -280,8 +284,14 @@ class ActualDiscordBot(commands.Bot):
 
     @commands.command(name="help")
     async def help(self, ctx: commands.Context) -> None:
-        """Show the same usage guide posted when the bot starts."""
-        await ctx.send(HELP_MESSAGE)
+        """Show the guide for the channel where the command was sent."""
+        if (
+            self.receipt_target_channel
+            and ctx.channel.id == self.receipt_target_channel.id
+        ):
+            await ctx.send(RECEIPT_HELP_MESSAGE)
+        else:
+            await ctx.send(NOTIFICATION_HELP_MESSAGE)
 
 
 async def main() -> None:

--- a/actual_discord_bot/bot.py
+++ b/actual_discord_bot/bot.py
@@ -22,6 +22,28 @@ REACTION_WARNING = "⚠️"
 MAX_ITEMS_IN_SUMMARY = 5
 MAX_RECEIPT_ATTACHMENT_BYTES = 10 * 1024 * 1024
 
+HELP_MESSAGE = """**Actual Budget bot — channel guide**
+
+I turn messages in the configured bank-notification channel into Actual Budget transactions. Currently I understand Bank Pekao card payments, incoming and outgoing transfers, and phone top-ups forwarded in this format:
+```
+Title: <notification title>
+Text: <notification text>
+Timestamp: <timestamp>
+```
+A ✅ means the transaction was saved. A message without ✅ was not imported; check the bot logs, correct the message if needed, and run `!catch_up`.
+
+In the configured receipts channel, attach one JPG, JPEG, PNG, WebP, or PDF receipt (maximum 10 MB). I extract the merchant, date, total, and items, then create one split transaction. I reply with the result and react with ✅ when created, ⚠️ for a duplicate or totals mismatch, and ❌ when processing fails. Receipt OCR is best-effort, so verify imported transactions in Actual Budget.
+
+**Commands**
+`!help` — show this guide
+`!catch_up` — retry every bank-channel message that does not already have my ✅
+
+Commands may be sent in either configured channel. I ignore other text in the receipts channel and unsupported attachments. Never post Actual or Discord passwords in a channel."""
+
+STARTUP_MESSAGE = (
+    "I am online and watching this channel. Here is how to use me:\n\n" + HELP_MESSAGE
+)
+
 
 class ActualDiscordBot(commands.Bot):
     def __init__(
@@ -35,11 +57,12 @@ class ActualDiscordBot(commands.Bot):
         self.actual_connector = actual_connector
         self.receipt_handler = receipt_handler
         self.receipt_processing_slots = asyncio.Semaphore(1)
+        self._startup_help_sent = False
 
         intents = discord.Intents.default()
         intents.message_content = True
         intents.members = True
-        super().__init__(command_prefix="!", intents=intents)
+        super().__init__(command_prefix="!", intents=intents, help_command=None)
         self.target_channel: discord.TextChannel | None = None
         self.receipt_target_channel: discord.TextChannel | None = None
 
@@ -59,6 +82,26 @@ class ActualDiscordBot(commands.Bot):
                 break
         if not self.target_channel:
             print(f"Warning: Could not find channel '{self.channel_name}'")
+
+        if not self._startup_help_sent:
+            await self._send_startup_help()
+            self._startup_help_sent = True
+
+    async def _send_startup_help(self) -> None:
+        """Announce the bot once per process in every configured channel found."""
+        channels = {channel.id: channel for channel in self._followed_channels()}
+        for channel in channels.values():
+            try:
+                await channel.send(STARTUP_MESSAGE)
+            except (discord.Forbidden, discord.HTTPException) as error:
+                print(f"Could not send startup help to '{channel.name}': {error}")
+
+    def _followed_channels(self) -> tuple[discord.TextChannel, ...]:
+        return tuple(
+            channel
+            for channel in (self.target_channel, self.receipt_target_channel)
+            if channel is not None
+        )
 
     async def create_actual_transaction(self, message: discord.Message) -> bool:
         try:
@@ -204,6 +247,11 @@ class ActualDiscordBot(commands.Bot):
         if message.author == self.user:
             return
 
+        context = await self.get_context(message)
+        if context.valid:
+            await self.invoke(context)
+            return
+
         if self.target_channel and message.channel.id == self.target_channel.id:
             await self.handle_message(message)
         elif (
@@ -229,6 +277,11 @@ class ActualDiscordBot(commands.Bot):
                     processed_count += 1
 
         await ctx.send(f"Catch-up complete. Processed {processed_count} messages.")
+
+    @commands.command(name="help")
+    async def help(self, ctx: commands.Context) -> None:
+        """Show the same usage guide posted when the bot starts."""
+        await ctx.send(HELP_MESSAGE)
 
 
 async def main() -> None:

--- a/actual_discord_bot/bot.py
+++ b/actual_discord_bot/bot.py
@@ -103,9 +103,22 @@ class ActualDiscordBot(commands.Bot):
             if channel is None:
                 continue
             try:
+                if await self._has_recent_guide(channel, guide):
+                    continue
                 await channel.send(guide)
             except (discord.Forbidden, discord.HTTPException) as error:
                 print(f"Could not send startup help to '{channel.name}': {error}")
+
+    async def _has_recent_guide(
+        self,
+        channel: discord.TextChannel,
+        guide: str,
+    ) -> bool:
+        """Return whether this bot posted the current guide in the last 10 messages."""
+        async for message in channel.history(limit=10):
+            if message.author == self.user and message.content == guide:
+                return True
+        return False
 
     async def create_actual_transaction(self, message: discord.Message) -> bool:
         try:

--- a/deployment/lan/.env.example
+++ b/deployment/lan/.env.example
@@ -1,0 +1,15 @@
+# Discord application bot token (keep this secret)
+DISCORD_TOKEN=replace-me
+DISCORD_BANK_NOTIFICATION_CHANNEL=bank-notifications
+DISCORD_RECEIPT_CHANNEL=receipts
+
+# Values configured in the Actual web application
+ACTUAL_PASSWORD=replace-me
+ACTUAL_FILE=My Finances
+ACTUAL_ENCRYPTION_PASSWORD=
+ACTUAL_ACCOUNT=Pekao
+
+# Local OCR settings
+OCR_PROVIDER=tesseract
+OCR_TESSERACT_LANG=pol
+OCR_TESSERACT_PSM=6

--- a/deployment/lan/compose.yml
+++ b/deployment/lan/compose.yml
@@ -1,0 +1,40 @@
+name: actual-budget-home
+
+services:
+  actual_server:
+    image: docker.io/actualbudget/actual-server:26.4.0
+    restart: unless-stopped
+    ports:
+      - "12012:5006"
+    volumes:
+      - actual_data:/data
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:5006').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+  bot:
+    build:
+      context: ../..
+    restart: unless-stopped
+    depends_on:
+      actual_server:
+        condition: service_healthy
+    environment:
+      DISCORD_TOKEN: ${DISCORD_TOKEN}
+      DISCORD_BANK_NOTIFICATION_CHANNEL: ${DISCORD_BANK_NOTIFICATION_CHANNEL}
+      DISCORD_RECEIPT_CHANNEL: ${DISCORD_RECEIPT_CHANNEL:-}
+      ACTUAL_URL: http://actual_server:5006
+      ACTUAL_PASSWORD: ${ACTUAL_PASSWORD}
+      ACTUAL_FILE: ${ACTUAL_FILE}
+      ACTUAL_ENCRYPTION_PASSWORD: ${ACTUAL_ENCRYPTION_PASSWORD:-}
+      ACTUAL_ACCOUNT: ${ACTUAL_ACCOUNT:-Pekao}
+      OCR_PROVIDER: ${OCR_PROVIDER:-tesseract}
+      OCR_TESSERACT_LANG: ${OCR_TESSERACT_LANG:-pol}
+      OCR_TESSERACT_PSM: ${OCR_TESSERACT_PSM:-6}
+    command: python -u -m actual_discord_bot.bot
+
+volumes:
+  actual_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 services:
   bot:
     build: .
+    restart: unless-stopped
+    depends_on:
+      actual_server:
+        condition: service_healthy
     volumes:
       - .:/app
     environment:
@@ -9,11 +13,12 @@ services:
       - ACTUAL_PASSWORD=${ACTUAL_PASSWORD}
       - ACTUAL_FILE=${ACTUAL_FILE}
       - ACTUAL_ACCOUNT=${ACTUAL_ACCOUNT:-Pekao}
+      - ACTUAL_ENCRYPTION_PASSWORD=${ACTUAL_ENCRYPTION_PASSWORD:-}
       - DISCORD_BANK_NOTIFICATION_CHANNEL=${DISCORD_BANK_NOTIFICATION_CHANNEL}
       - DISCORD_RECEIPT_CHANNEL=${DISCORD_RECEIPT_CHANNEL:-}
       - OCR_PROVIDER=${OCR_PROVIDER:-tesseract}
 
-    command: python -u actual_discord_bot/bot.py
+    command: python -u -m actual_discord_bot.bot
 
   actual_server:
     image: docker.io/actualbudget/actual-server:26.4.0
@@ -22,6 +27,12 @@ services:
     volumes:
       - ./actual-data:/data
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:5006').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
   test_actual_server:
     image: docker.io/actualbudget/actual-server:26.4.0

--- a/tests/unit_tests/test_bot.py
+++ b/tests/unit_tests/test_bot.py
@@ -364,6 +364,62 @@ async def test_startup_help_sends_both_guides_for_shared_channel(bot):
 
 
 @pytest.mark.asyncio
+async def test_startup_help_skips_matching_guide_in_last_ten_messages(bot):
+    channel = AsyncMock(spec=discord.TextChannel)
+    channel.id = 1
+    channel.name = "bank-notifications"
+    bot.target_channel = channel
+    bot_user = MagicMock()
+    recent_guide = MagicMock(
+        author=bot_user,
+        content=NOTIFICATION_HELP_MESSAGE,
+    )
+    channel.history.return_value.__aiter__.return_value = [recent_guide]
+
+    with patch.object(
+        type(bot), "user", new_callable=lambda: property(lambda _: bot_user)
+    ):
+        await bot._send_startup_help()  # noqa: SLF001
+
+    channel.history.assert_called_once_with(limit=10)
+    channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_startup_help_posts_when_recent_guide_is_not_from_bot(bot):
+    channel = AsyncMock(spec=discord.TextChannel)
+    channel.id = 1
+    channel.name = "bank-notifications"
+    bot.target_channel = channel
+    recent_guide = MagicMock(
+        author=MagicMock(),
+        content=NOTIFICATION_HELP_MESSAGE,
+    )
+    channel.history.return_value.__aiter__.return_value = [recent_guide]
+
+    with patch.object(
+        type(bot), "user", new_callable=lambda: property(lambda _: MagicMock())
+    ):
+        await bot._send_startup_help()  # noqa: SLF001
+
+    channel.send.assert_awaited_once_with(NOTIFICATION_HELP_MESSAGE)
+
+
+@pytest.mark.asyncio
+async def test_startup_help_posts_when_bot_guide_is_older_than_history_window(bot):
+    channel = AsyncMock(spec=discord.TextChannel)
+    channel.id = 1
+    channel.name = "bank-notifications"
+    bot.target_channel = channel
+    channel.history.return_value.__aiter__.return_value = []
+
+    await bot._send_startup_help()  # noqa: SLF001
+
+    channel.history.assert_called_once_with(limit=10)
+    channel.send.assert_awaited_once_with(NOTIFICATION_HELP_MESSAGE)
+
+
+@pytest.mark.asyncio
 async def test_help_command_sends_notification_guide(bot, ctx):
     ctx.channel.id = 1
     await bot.help.callback(bot, ctx)

--- a/tests/unit_tests/test_bot.py
+++ b/tests/unit_tests/test_bot.py
@@ -5,6 +5,7 @@ import pytest
 
 import actual_discord_bot.bot as bot_module
 from actual_discord_bot import ActualDiscordBot
+from actual_discord_bot.bot import HELP_MESSAGE, STARTUP_MESSAGE
 from actual_discord_bot.config import DiscordConfig
 from actual_discord_bot.errors import ParseNotificationError
 
@@ -306,9 +307,11 @@ async def test_on_message_ignores_own_messages():
 
 @pytest.mark.asyncio
 async def test_on_ready_finds_bank_and_receipt_channels(bot):
-    bank_channel = MagicMock(spec=discord.TextChannel)
+    bank_channel = AsyncMock(spec=discord.TextChannel)
+    bank_channel.id = 1
     bank_channel.name = "bank-notifications"
-    receipt_channel = MagicMock(spec=discord.TextChannel)
+    receipt_channel = AsyncMock(spec=discord.TextChannel)
+    receipt_channel.id = 2
     receipt_channel.name = "receipts"
     guild = MagicMock()
     guild.channels = [bank_channel, receipt_channel]
@@ -321,6 +324,62 @@ async def test_on_ready_finds_bank_and_receipt_channels(bot):
 
     assert bot.target_channel is bank_channel
     assert bot.receipt_target_channel is receipt_channel
+    bank_channel.send.assert_awaited_once_with(STARTUP_MESSAGE)
+    receipt_channel.send.assert_awaited_once_with(STARTUP_MESSAGE)
+
+
+@pytest.mark.asyncio
+async def test_on_ready_only_sends_startup_help_once(bot):
+    bank_channel = AsyncMock(spec=discord.TextChannel)
+    bank_channel.id = 1
+    bank_channel.name = "bank-notifications"
+    guild = MagicMock(channels=[bank_channel])
+
+    with patch.object(
+        type(bot), "guilds", new_callable=lambda: property(lambda _: [guild])
+    ):
+        await bot.on_ready()
+        await bot.on_ready()
+
+    bank_channel.send.assert_awaited_once_with(STARTUP_MESSAGE)
+
+
+@pytest.mark.asyncio
+async def test_startup_help_is_not_duplicated_for_shared_channel(bot):
+    channel = AsyncMock(spec=discord.TextChannel)
+    channel.id = 1
+    channel.name = "shared"
+    bot.target_channel = channel
+    bot.receipt_target_channel = channel
+
+    await bot._send_startup_help()  # noqa: SLF001
+
+    channel.send.assert_awaited_once_with(STARTUP_MESSAGE)
+
+
+@pytest.mark.asyncio
+async def test_help_command_sends_usage_guide(bot, ctx):
+    await bot.help.callback(bot, ctx)
+
+    ctx.send.assert_awaited_once_with(HELP_MESSAGE)
+
+
+@pytest.mark.asyncio
+async def test_on_message_invokes_valid_command_instead_of_importing(bot):
+    message = AsyncMock(spec=discord.Message)
+    message.author = MagicMock()
+    context = MagicMock(valid=True)
+
+    with (
+        patch.object(type(bot), "user", new_callable=lambda: property(lambda _: None)),
+        patch.object(bot, "get_context", new=AsyncMock(return_value=context)),
+        patch.object(bot, "invoke", new=AsyncMock()) as invoke,
+        patch.object(bot, "handle_message", new=AsyncMock()) as handle_message,
+    ):
+        await bot.on_message(message)
+
+    invoke.assert_awaited_once_with(context)
+    handle_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_bot.py
+++ b/tests/unit_tests/test_bot.py
@@ -5,7 +5,10 @@ import pytest
 
 import actual_discord_bot.bot as bot_module
 from actual_discord_bot import ActualDiscordBot
-from actual_discord_bot.bot import HELP_MESSAGE, STARTUP_MESSAGE
+from actual_discord_bot.bot import (
+    NOTIFICATION_HELP_MESSAGE,
+    RECEIPT_HELP_MESSAGE,
+)
 from actual_discord_bot.config import DiscordConfig
 from actual_discord_bot.errors import ParseNotificationError
 
@@ -324,8 +327,8 @@ async def test_on_ready_finds_bank_and_receipt_channels(bot):
 
     assert bot.target_channel is bank_channel
     assert bot.receipt_target_channel is receipt_channel
-    bank_channel.send.assert_awaited_once_with(STARTUP_MESSAGE)
-    receipt_channel.send.assert_awaited_once_with(STARTUP_MESSAGE)
+    bank_channel.send.assert_awaited_once_with(NOTIFICATION_HELP_MESSAGE)
+    receipt_channel.send.assert_awaited_once_with(RECEIPT_HELP_MESSAGE)
 
 
 @pytest.mark.asyncio
@@ -341,11 +344,11 @@ async def test_on_ready_only_sends_startup_help_once(bot):
         await bot.on_ready()
         await bot.on_ready()
 
-    bank_channel.send.assert_awaited_once_with(STARTUP_MESSAGE)
+    bank_channel.send.assert_awaited_once_with(NOTIFICATION_HELP_MESSAGE)
 
 
 @pytest.mark.asyncio
-async def test_startup_help_is_not_duplicated_for_shared_channel(bot):
+async def test_startup_help_sends_both_guides_for_shared_channel(bot):
     channel = AsyncMock(spec=discord.TextChannel)
     channel.id = 1
     channel.name = "shared"
@@ -354,14 +357,30 @@ async def test_startup_help_is_not_duplicated_for_shared_channel(bot):
 
     await bot._send_startup_help()  # noqa: SLF001
 
-    channel.send.assert_awaited_once_with(STARTUP_MESSAGE)
+    assert channel.send.await_args_list == [
+        ((NOTIFICATION_HELP_MESSAGE,), {}),
+        ((RECEIPT_HELP_MESSAGE,), {}),
+    ]
 
 
 @pytest.mark.asyncio
-async def test_help_command_sends_usage_guide(bot, ctx):
+async def test_help_command_sends_notification_guide(bot, ctx):
+    ctx.channel.id = 1
     await bot.help.callback(bot, ctx)
 
-    ctx.send.assert_awaited_once_with(HELP_MESSAGE)
+    ctx.send.assert_awaited_once_with(NOTIFICATION_HELP_MESSAGE)
+
+
+@pytest.mark.asyncio
+async def test_help_command_sends_receipt_guide(bot, ctx):
+    receipt_channel = MagicMock(spec=discord.TextChannel)
+    receipt_channel.id = 2
+    bot.receipt_target_channel = receipt_channel
+    ctx.channel.id = 2
+
+    await bot.help.callback(bot, ctx)
+
+    ctx.send.assert_awaited_once_with(RECEIPT_HELP_MESSAGE)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- post a detailed usage guide once per configured Discord channel when the bot starts
- add an on-demand `!help` command and restore command dispatch from the custom message handler
- document a complete home-LAN setup for Actual Server, Discord, Automate, daily operation, and troubleshooting
- add a production-oriented `deployment/lan` Compose stack and environment template
- add health checks, restart policies, encryption configuration, and a reliable module entry point for the production image
- cover startup announcements, reconnect behavior, shared channels, help output, and command routing with unit tests

## Why

The bot previously gave users no in-channel onboarding, and its custom `on_message` implementation prevented documented commands from being dispatched. The existing README and Compose setup were development-focused and did not provide a reliable end-to-end path for a persistent home deployment.

## User impact

A user can now follow one LAN-focused walkthrough to run Actual and the bot on a home Linux host, access Actual from a phone on local Wi-Fi, configure Discord and Automate, and understand bot behavior directly in each watched channel.

## Validation

- `pytest tests/unit_tests/` — 145 passed
- `pre-commit run --all-files` — passed
- both Compose configurations validated with `docker compose config --quiet`
- production bot image built successfully
- installed bot module imported successfully inside the production image