### PR TITLE
Fix Dependabot reviewer status

### DIFF
--- a/.github/workflows/dependabot_updates.yml
+++ b/.github/workflows/dependabot_updates.yml
@@ -41,7 +41,10 @@ jobs:
         if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-major' && steps.dependabot-metadata.outputs.dependency-type == 'direct:production' }}
         run: |
           gh pr comment $PR_URL --body "I'm **not approving** this PR because **it includes a major update of a dependency used in production**"
-          gh pr edit $PR_URL --add-label "requires-manual-qa"
+          labels="$(gh label list --search "requires-manual-qa" --json name --jq '.[].name')"
+          if grep -Fxq "requires-manual-qa" <<< "$labels"; then
+            gh pr edit $PR_URL --add-label "requires-manual-qa"
+          fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Avoid failing the Dependabot reviewer when a production major update is intentionally not approved and the optional manual-QA label has not been created.

The workflow continues to enable auto-merge for every Dependabot PR and retains the existing approval rules. GitHub command failures still fail the job.

## Validation

- Parsed the workflow as YAML
- Checked the embedded shell syntax
- Ran `git diff --check`