### PR TITLE
Improve notification status feedback

### DIFF
--- a/actual_discord_bot/channel_handlers/notifications.py
+++ b/actual_discord_bot/channel_handlers/notifications.py
@@ -18,6 +18,7 @@ from actual_discord_bot.dataclasses_definitions import ActualTransactionData
 from actual_discord_bot.errors import ParseNotificationError
 
 LOGGER = logging.getLogger(__name__)
+ERROR_REACTION = "❌"
 
 NOTIFICATION_HELP_MESSAGE = """👋 **Hello! I am your Actual Budget notification assistant.**
 
@@ -27,7 +28,9 @@ Title: <notification title>
 Text: <notification text>
 Timestamp: <timestamp>
 ```
-A ✅ means the transaction was saved. A message without ✅ was not imported; check the bot logs, correct the cause if needed, and run `!catch_up`.
+I react with ✅ and reply with a summary when a transaction is created. If a notification cannot be read or imported, I react with ❌ and reply with the reason. Unexpected import errors are logged for troubleshooting.
+
+`!catch_up` skips messages marked with my ✅ or ❌. To request a retry, add any reaction to the message; I will try it again and remove that reaction afterwards, whether the retry succeeds or fails.
 
 **How notifications reach this channel**
 An administrator can create a Discord webhook for this channel in **Edit Channel → Integrations → Webhooks**. Its webhook URL is the special link that can post messages here—keep it private. On Android, an Automate flow can listen only for notifications from your bank app and send an HTTP POST to that URL, using `application/json` and the format above in the JSON `content` field. Never put your Discord bot token or Actual password in the flow or channel.
@@ -69,12 +72,23 @@ class NotificationChannelHandler(BaseChannelHandler):
             await self._save_transaction(transaction_data)
         except ParseNotificationError:
             LOGGER.info("Could not parse bank notification message %s", message.id)
+            await message.add_reaction(ERROR_REACTION)
+            await message.reply(
+                "Could not import notification: its format is not supported. "
+                "Check that it was forwarded in the expected format."
+            )
             return MessageHandlingResult.FAILED
         except Exception:
             LOGGER.exception("Error importing bank notification message %s", message.id)
+            await message.add_reaction(ERROR_REACTION)
+            await message.reply(
+                "An unexpected error occurred while importing the notification. "
+                "The error has been logged."
+            )
             return MessageHandlingResult.FAILED
 
         await message.add_reaction(SUCCESS_REACTION)
+        await message.reply(_format_transaction_summary(transaction_data, self.actual_connector))
         return MessageHandlingResult.IMPORTED
 
     async def _save_transaction(self, transaction_data: ActualTransactionData) -> None:
@@ -89,7 +103,7 @@ class NotificationChannelHandler(BaseChannelHandler):
             )
 
     async def catch_up(self, ctx: commands.Context) -> None:
-        """Retry all messages that do not already have this bot's success reaction."""
+        """Retry unmarked messages and messages explicitly marked by a user."""
         if self.channel is None:
             await ctx.send(f"Error: Channel '{self.channel_name}' not found.")
             return
@@ -97,16 +111,57 @@ class NotificationChannelHandler(BaseChannelHandler):
         processed_count = 0
         async with ctx.typing():
             async for message in self.channel.history(limit=None):
-                if self._has_success_reaction(message):
+                if not self._should_retry(message):
                     continue
-                await self.handle(message)
+                try:
+                    await self.handle(message)
+                finally:
+                    await self._remove_external_reactions(message)
                 processed_count += 1
 
         await ctx.send(f"Catch-up complete. Processed {processed_count} messages.")
 
     @staticmethod
-    def _has_success_reaction(message: discord.Message) -> bool:
-        return any(
-            reaction.emoji == SUCCESS_REACTION and reaction.me
+    def _should_retry(message: discord.Message) -> bool:
+        """Return whether a message has no bot status or has a user retry marker."""
+        has_bot_status = any(
+            reaction.emoji in {SUCCESS_REACTION, ERROR_REACTION} and reaction.me
             for reaction in message.reactions
         )
+        has_external_reaction = any(
+            not reaction.me
+            or (
+                isinstance(reaction.count, int)
+                and reaction.count > 1
+            )
+            for reaction in message.reactions
+        )
+        return not has_bot_status or has_external_reaction
+
+    @staticmethod
+    async def _remove_external_reactions(message: discord.Message) -> None:
+        """Remove user retry markers without clearing this bot's status reactions."""
+        for reaction in message.reactions:
+            async for user in reaction.users():
+                if user.bot:
+                    continue
+                try:
+                    await message.remove_reaction(reaction.emoji, user)
+                except discord.HTTPException:
+                    LOGGER.warning(
+                        "Could not remove retry reaction from bank notification message %s",
+                        message.id,
+                    )
+
+
+def _format_transaction_summary(
+    transaction_data: ActualTransactionData, actual_connector: ActualConnector
+) -> str:
+    """Format the details that Actual assigns to notification transactions."""
+    payee = transaction_data.imported_payee or "Unknown payee"
+    budget = actual_connector.config.file
+    return (
+        f"Created transaction: **{payee}**, {abs(transaction_data.amount)} PLN\n"
+        f"Budget: **{budget}** · Account: **{transaction_data.account}** · "
+        "Category: *Uncategorized*"
+    )

--- a/tests/unit_tests/test_notification_channel_handler.py
+++ b/tests/unit_tests/test_notification_channel_handler.py
@@ -1,12 +1,16 @@
+from datetime import date
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import discord
 import pytest
 
 from actual_discord_bot.channel_handlers.notifications import (
+    ERROR_REACTION,
     MessageHandlingResult,
     NotificationChannelHandler,
 )
+from actual_discord_bot.dataclasses_definitions import ActualTransactionData
 from actual_discord_bot.errors import ParseNotificationError
 
 
@@ -21,6 +25,13 @@ async def test_successful_notification_is_saved_in_a_worker_and_reacted(handler)
     message.id = 1
     message.content = "notification"
     notification = MagicMock()
+    notification.to_transaction.return_value = ActualTransactionData(
+        date=date(2026, 8, 2),
+        account="Pekao",
+        amount=Decimal("-12.34"),
+        imported_payee="Shop",
+    )
+    handler.actual_connector.config.file = "Household"
     handler.notification_type.from_message.return_value = notification
     result = await handler.handle(message)
     assert result is MessageHandlingResult.IMPORTED
@@ -28,10 +39,14 @@ async def test_successful_notification_is_saved_in_a_worker_and_reacted(handler)
         notification.to_transaction.return_value
     )
     message.add_reaction.assert_awaited_once_with("✅")
+    message.reply.assert_awaited_once_with(
+        "Created transaction: **Shop**, 12.34 PLN\n"
+        "Budget: **Household** · Account: **Pekao** · Category: *Uncategorized*"
+    )
 
 
 @pytest.mark.asyncio
-async def test_parse_error_does_not_add_success_reaction(handler):
+async def test_parse_error_is_marked_and_explained(handler):
     message = AsyncMock(spec=discord.Message)
     message.id = 1
     message.content = "invalid"
@@ -40,19 +55,43 @@ async def test_parse_error_does_not_add_success_reaction(handler):
     )
     result = await handler.handle(message)
     assert result is MessageHandlingResult.FAILED
-    message.add_reaction.assert_not_awaited()
+    message.add_reaction.assert_awaited_once_with(ERROR_REACTION)
+    message.reply.assert_awaited_once_with(
+        "Could not import notification: its format is not supported. "
+        "Check that it was forwarded in the expected format."
+    )
 
 
 @pytest.mark.asyncio
-async def test_catch_up_skips_only_own_success_reactions(handler):
+async def test_unexpected_error_is_logged_and_translated_to_a_discord_reply(handler):
+    message = AsyncMock(spec=discord.Message)
+    message.id = 1
+    message.content = "notification"
+    handler.notification_type.from_message.side_effect = RuntimeError("connection lost")
+
+    result = await handler.handle(message)
+
+    assert result is MessageHandlingResult.FAILED
+    message.add_reaction.assert_awaited_once_with(ERROR_REACTION)
+    message.reply.assert_awaited_once_with(
+        "An unexpected error occurred while importing the notification. "
+        "The error has been logged."
+    )
+
+
+@pytest.mark.asyncio
+async def test_catch_up_skips_bot_status_reactions_and_retries_unmarked_messages(handler):
     channel = AsyncMock(spec=discord.TextChannel)
     handler.channel = channel
     already_imported = AsyncMock(spec=discord.Message)
     already_imported.reactions = [MagicMock(emoji="✅", me=True)]
+    failed_import = AsyncMock(spec=discord.Message)
+    failed_import.reactions = [MagicMock(emoji="❌", me=True)]
     needs_import = AsyncMock(spec=discord.Message)
-    needs_import.reactions = [MagicMock(emoji="👍", me=True)]
+    needs_import.reactions = []
     channel.history.return_value.__aiter__.return_value = [
         already_imported,
+        failed_import,
         needs_import,
     ]
     ctx = MagicMock()
@@ -63,3 +102,29 @@ async def test_catch_up_skips_only_own_success_reactions(handler):
     await handler.catch_up(ctx)
     handler.handle.assert_awaited_once_with(needs_import)
     ctx.send.assert_awaited_once_with("Catch-up complete. Processed 1 messages.")
+
+
+@pytest.mark.asyncio
+async def test_catch_up_retries_user_marked_messages_and_removes_the_marker(handler):
+    channel = AsyncMock(spec=discord.TextChannel)
+    handler.channel = channel
+    user = MagicMock(bot=False)
+    retry_marker = MagicMock(emoji="🔄", me=False, count=1)
+    retry_marker.users.return_value.__aiter__.return_value = [user]
+    failed_import = AsyncMock(spec=discord.Message)
+    failed_import.id = 1
+    failed_import.reactions = [
+        MagicMock(emoji="❌", me=True, count=1),
+        retry_marker,
+    ]
+    channel.history.return_value.__aiter__.return_value = [failed_import]
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+    ctx.typing.return_value.__aenter__ = AsyncMock(return_value=None)
+    ctx.typing.return_value.__aexit__ = AsyncMock(return_value=None)
+    handler.handle = AsyncMock()
+
+    await handler.catch_up(ctx)
+
+    handler.handle.assert_awaited_once_with(failed_import)
+    failed_import.remove_reaction.assert_awaited_once_with("🔄", user)


### PR DESCRIPTION
## Summary

- Reply with a detailed Actual transaction summary after a successful notification import.
- Mark failed notification imports with ❌ and explain whether the format was unsupported or an internal error was logged.
- Make catch-up skip bot status markers unless a user explicitly reacts to request a retry, then remove that retry reaction after processing.
- Document the notification status and retry behavior in the channel guide.

## Why

Notification imports previously had no user-facing failure reason or successful transaction summary, and failed messages were retried indefinitely.

## Validation

- `venv/bin/pytest tests/unit_tests` (133 passed)
- `venv/bin/ruff check actual_discord_bot/channel_handlers/notifications.py tests/unit_tests/test_notification_channel_handler.py`