### PR TITLE
Register bot commands

### DIFF
--- a/actual_discord_bot/bot.py
+++ b/actual_discord_bot/bot.py
@@ -35,6 +35,8 @@ class ActualDiscordBot(commands.Bot):
         super().__init__(command_prefix="!", intents=intents, help_command=None)
         self.notification_handler = notification_handler
         self.receipt_handler = receipt_handler
+        self.add_command(self.catch_up)
+        self.add_command(self.help)
         self.handlers: tuple[BaseChannelHandler, ...] = tuple(
             handler
             for handler in (receipt_handler, notification_handler)

--- a/tests/unit_tests/test_bot.py
+++ b/tests/unit_tests/test_bot.py
@@ -45,6 +45,11 @@ async def test_on_ready_binds_all_handlers_across_guilds_and_announces(bot):
     assert receipt_handler.channel is receipt_channel
 
 
+def test_registers_commands(bot):
+    assert bot.get_command("catch_up") is bot.catch_up
+    assert bot.get_command("help") is bot.help
+
+
 @pytest.mark.asyncio
 async def test_on_message_invokes_valid_command_before_handlers(bot):
     message = AsyncMock(spec=discord.Message)


### PR DESCRIPTION
## Summary

Registers the `help` and `catch_up` class-defined commands with the Discord bot when it is initialized.

## Root cause

Class-level `@commands.command` declarations were not added to the `commands.Bot` registry. As a result, Discord treated `!help` and `!catch_up` as ordinary bank-notification text and passed them to the notification parser.

## Validation

- `venv/bin/pytest tests/unit_tests -q` (134 passed)
- `venv/bin/ruff check actual_discord_bot/bot.py tests/unit_tests/test_bot.py`

The new regression test confirms both commands are present in the actual command registry.