### PR TITLE
Fix production bot startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ an existing receipt.
 - **Discount handling** — Recognizes OBNIŻKA/RABAT/UPUST discount lines and includes them as negative sub-transactions
 - **Idempotent catch-up** — `!catch_up` command processes all unprocessed messages in the channel (skips already-reacted ones)
 - **In-channel guidance** — Posts a complete usage guide on startup and provides it on demand with `!help`
-- **Hot-reload** — Uses [cogwatch](https://github.com/robertwayne/cogwatch) for live code reloading during development
+- **Hot-reload** — Uses [cogwatch](https://github.com/robertwayne/cogwatch) only in the development Compose stack
 - **Dockerized deployment** — Full Docker Compose setup with bot, Actual server, and integration test services
 
 ## Architecture
@@ -236,6 +236,7 @@ The bot is configured with these environment variables:
 DISCORD_TOKEN=your_discord_bot_token
 DISCORD_BANK_NOTIFICATION_CHANNEL=bank-notifications  # channel name (not ID)
 DISCORD_RECEIPT_CHANNEL=receipts                      # optional: channel for receipt photos/PDFs
+DISCORD_HOT_RELOAD=false                              # development-only source watcher
 
 # Actual Budget
 ACTUAL_URL=http://actual_server:5006    # Compose service URL used by the bot
@@ -255,6 +256,7 @@ OCR_TESSERACT_PSM=6                     # Tesseract page segmentation mode (defa
 | `DISCORD_TOKEN` | Yes | Discord bot token |
 | `DISCORD_BANK_NOTIFICATION_CHANNEL` | Yes | Name of the channel to monitor for bank notifications |
 | `DISCORD_RECEIPT_CHANNEL` | No | Name of the channel for receipt photos/PDFs |
+| `DISCORD_HOT_RELOAD` | No | Enable source watching in a development checkout (default: `false`) |
 | `ACTUAL_URL` | Yes | Actual Budget server URL |
 | `ACTUAL_PASSWORD` | Yes | Actual server password |
 | `ACTUAL_FILE` | Yes | Budget file name or sync ID |
@@ -273,8 +275,13 @@ OCR_TESSERACT_PSM=6                     # Tesseract page segmentation mode (defa
 docker compose up bot
 
 # Or directly
-python -m actual_discord_bot.bot
+DISCORD_HOT_RELOAD=true python -m actual_discord_bot.bot
 ```
+
+The development Compose stack enables `DISCORD_HOT_RELOAD=true` and watches the
+mounted `actual_discord_bot/` source tree. Production leaves it disabled by default.
+If the development source tree is unavailable, the bot logs a warning and continues
+without hot reload rather than blocking Discord startup.
 
 ### Bot Commands
 
@@ -333,7 +340,7 @@ ruff format .
 
 - **[discord.py](https://discordpy.readthedocs.io/)** — Discord API wrapper
 - **[actualpy](https://actualpy.readthedocs.io/)** — Python client for Actual Budget API
-- **[cogwatch](https://github.com/robertwayne/cogwatch)** — Hot-reload for discord.py cogs
+- **[cogwatch](https://github.com/robertwayne/cogwatch)** — Development-only source watcher
 - **[environ-config](https://environ-config.readthedocs.io/)** — Typed environment configuration
 - **[Babel](https://babel.pocoo.org/)** — Number/locale parsing (Polish decimal format)
 - **[Pillow](https://pillow.readthedocs.io/)** — Image preprocessing for OCR

--- a/actual_discord_bot/bot.py
+++ b/actual_discord_bot/bot.py
@@ -2,10 +2,11 @@
 
 import asyncio
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import discord
-from cogwatch import watch  # type: ignore[import-untyped]
+from cogwatch import Watcher  # type: ignore[import-untyped]
 from discord.ext import commands
 
 from actual_discord_bot.actual_connector import ActualConnector
@@ -28,6 +29,8 @@ class ActualDiscordBot(commands.Bot):
         self,
         notification_handler: NotificationChannelHandler,
         receipt_handler: ReceiptChannelHandler | None = None,
+        *,
+        hot_reload: bool = False,
     ) -> None:
         intents = discord.Intents.default()
         intents.message_content = True
@@ -35,6 +38,7 @@ class ActualDiscordBot(commands.Bot):
         super().__init__(command_prefix="!", intents=intents, help_command=None)
         self.notification_handler = notification_handler
         self.receipt_handler = receipt_handler
+        self.hot_reload = hot_reload
         self.add_command(self.catch_up)
         self.add_command(self.help)
         self.handlers: tuple[BaseChannelHandler, ...] = tuple(
@@ -43,7 +47,21 @@ class ActualDiscordBot(commands.Bot):
             if handler is not None
         )
 
-    @watch(path="actual_discord_bot")
+    async def setup_hook(self) -> None:
+        """Start development hot reload only when its watched source tree exists."""
+        if not self.hot_reload:
+            return
+
+        source_path = Path("actual_discord_bot")
+        if not source_path.is_dir():
+            LOGGER.warning(
+                "Discord hot reload is enabled but %s does not exist; continuing without it",
+                source_path.resolve(),
+            )
+            return
+
+        await Watcher(self, path=str(source_path)).start()
+
     async def on_ready(self) -> None:
         for handler in self.handlers:
             handler.bind(self.guilds)
@@ -106,7 +124,11 @@ async def main() -> None:
             receipt_processor,
             actual_write_lock=actual_write_lock,
         )
-    client = ActualDiscordBot(notification_handler, receipt_handler)
+    client = ActualDiscordBot(
+        notification_handler,
+        receipt_handler,
+        hot_reload=discord_config.hot_reload,
+    )
     await client.start(discord_config.token)
 
 

--- a/actual_discord_bot/config.py
+++ b/actual_discord_bot/config.py
@@ -15,3 +15,4 @@ class DiscordConfig:
     token: str = environ.var()
     bank_notification_channel: str = environ.var()
     receipt_channel: str = environ.var(default="")
+    hot_reload: bool = environ.bool_var(default=False)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - .:/app
     environment:
       - DISCORD_TOKEN=${DISCORD_TOKEN}
+      - DISCORD_HOT_RELOAD=true
       - ACTUAL_URL=http://actual_server:5006
       - ACTUAL_PASSWORD=${ACTUAL_PASSWORD}
       - ACTUAL_FILE=${ACTUAL_FILE}

--- a/tests/unit_tests/test_bot.py
+++ b/tests/unit_tests/test_bot.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
@@ -43,6 +44,43 @@ async def test_on_ready_binds_all_handlers_across_guilds_and_announces(bot):
 
     assert bot.notification_handler.channel is notification_channel
     assert receipt_handler.channel is receipt_channel
+
+
+@pytest.mark.asyncio
+async def test_setup_hook_skips_hot_reload_by_default(bot):
+    with patch.object(bot_module, "Watcher") as watcher:
+        await bot.setup_hook()
+
+    watcher.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_setup_hook_warns_and_continues_when_source_tree_is_missing(
+    notification_handler, monkeypatch, tmp_path, caplog
+):
+    bot = ActualDiscordBot(notification_handler, hot_reload=True)
+    monkeypatch.chdir(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger=bot_module.LOGGER.name):
+        await bot.setup_hook()
+
+    assert "continuing without it" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_setup_hook_starts_hot_reload_when_source_tree_exists(
+    notification_handler, monkeypatch, tmp_path
+):
+    (tmp_path / "actual_discord_bot").mkdir()
+    bot = ActualDiscordBot(notification_handler, hot_reload=True)
+    monkeypatch.chdir(tmp_path)
+    watcher = MagicMock(start=AsyncMock())
+
+    with patch.object(bot_module, "Watcher", return_value=watcher) as watcher_factory:
+        await bot.setup_hook()
+
+    watcher_factory.assert_called_once_with(bot, path="actual_discord_bot")
+    watcher.start.assert_awaited_once()
 
 
 def test_registers_commands(bot):
@@ -152,7 +190,10 @@ async def test_catch_up_delegates_to_notification_handler(bot):
 @pytest.mark.parametrize("receipt_channel", ["", "receipts"])
 async def test_main_configures_optional_receipt_stack(receipt_channel):
     discord_config = MagicMock(
-        receipt_channel=receipt_channel, bank_notification_channel="bank", token="token"
+        receipt_channel=receipt_channel,
+        bank_notification_channel="bank",
+        token="token",
+        hot_reload=False,
     )
     client = MagicMock(start=AsyncMock())
     with (
@@ -170,6 +211,7 @@ async def test_main_configures_optional_receipt_stack(receipt_channel):
     ):
         await bot_module.main()
     client.start.assert_awaited_once_with("token")
+    assert discord_bot.call_args.kwargs["hot_reload"] is False
     if receipt_channel:
         processor.assert_called_once()
         assert discord_bot.call_args.args[1] is not None


### PR DESCRIPTION
## What changed

- makes Discord hot reload an explicit `DISCORD_HOT_RELOAD` development setting, disabled by default
- starts `cogwatch` only when the watched source directory exists
- keeps the root development Compose stack opt-in enabled and documents the behavior
- adds coverage for disabled, missing-path, and enabled watcher startup

## Why

The packaged production image installs the bot outside `/app/actual_discord_bot`. The previous `@watch` decorator waited indefinitely for that absent development path during `on_ready`, blocking handler binding and Discord event-loop progress.

## Impact

Production startup no longer depends on a checkout path. Development hot reload remains available; an invalid development path now logs a warning and continues without it.

## Validation

- `poetry run ruff check .`
- `poetry run pytest tests/unit_tests` (137 passed)
- `poetry run ruff format --check actual_discord_bot/bot.py actual_discord_bot/config.py tests/unit_tests/test_bot.py`
- `docker compose config --quiet`