### PR TITLE
Disable PyPI publishing workflow

### DIFF
--- a/.github/workflows/pypi_deploy.yml.disabled
+++ b/.github/workflows/pypi_deploy.yml.disabled
@@ -1,4 +1,5 @@
-# This workflow deploys a new release on PyPI once a pull request is closed
+# Disabled pending a PyPI publishing fix. Rename this file back to
+# `pypi_deploy.yml` to re-enable the workflow.
 
 name: Deploy to PyPI
 


### PR DESCRIPTION
## Summary

Disables the PyPI publishing workflow by renaming it outside GitHub Actions' workflow file pattern.

## Why

The current PyPI publishing step is not working and is not needed for now. The workflow definition is retained as `pypi_deploy.yml.disabled` so it can be restored later by renaming it back to `pypi_deploy.yml`.

## Impact

Pushing a `v*` tag will no longer attempt to publish a package to PyPI.

## Validation

- `git diff --check`