### PR TITLE
Fix Discord command callback binding

### DIFF
--- a/actual_discord_bot/bot.py
+++ b/actual_discord_bot/bot.py
@@ -39,8 +39,15 @@ class ActualDiscordBot(commands.Bot):
         self.notification_handler = notification_handler
         self.receipt_handler = receipt_handler
         self.hot_reload = hot_reload
-        self.add_command(self.catch_up)
-        self.add_command(self.help)
+
+        async def catch_up_command(ctx: commands.Context) -> None:
+            await self._catch_up(ctx)
+
+        async def help_command(ctx: commands.Context) -> None:
+            await self._help(ctx)
+
+        self.add_command(commands.Command(catch_up_command, name="catch_up"))
+        self.add_command(commands.Command(help_command, name="help"))
         self.handlers: tuple[BaseChannelHandler, ...] = tuple(
             handler
             for handler in (receipt_handler, notification_handler)
@@ -85,13 +92,11 @@ class ActualDiscordBot(commands.Bot):
                     )
                 return
 
-    @commands.command(name="catch_up")  # type: ignore[type-var]
-    async def catch_up(self, ctx: commands.Context) -> None:
+    async def _catch_up(self, ctx: commands.Context) -> None:
         """Retry notification messages that have not yet been imported."""
         await self.notification_handler.catch_up(ctx)
 
-    @commands.command(name="help")  # type: ignore[type-var]
-    async def help(self, ctx: commands.Context) -> None:
+    async def _help(self, ctx: commands.Context) -> None:
         """Show the guide or guides for the current channel."""
         matching_handlers = [
             handler for handler in self.handlers if handler.matches(ctx.channel)

--- a/tests/unit_tests/test_bot.py
+++ b/tests/unit_tests/test_bot.py
@@ -83,9 +83,11 @@ async def test_setup_hook_starts_hot_reload_when_source_tree_exists(
     watcher.start.assert_awaited_once()
 
 
-def test_registers_commands(bot):
-    assert bot.get_command("catch_up") is bot.catch_up
-    assert bot.get_command("help") is bot.help
+def test_registers_commands_with_context_only_callbacks(bot):
+    for name in ("catch_up", "help"):
+        command = bot.get_command(name)
+        assert command is not None
+        assert "self" not in command.params
 
 
 @pytest.mark.asyncio
@@ -169,7 +171,9 @@ async def test_help_sends_both_shared_channel_guides():
     receipt_handler.channel = channel
     ctx = AsyncMock()
     ctx.channel = channel
-    await bot.help.callback(bot, ctx)
+    command = bot.get_command("help")
+    assert command is not None
+    await command.callback(ctx)
     assert ctx.send.await_args_list == [
         ((RECEIPT_HELP_MESSAGE,), {}),
         ((NOTIFICATION_HELP_MESSAGE,), {}),
@@ -182,7 +186,9 @@ async def test_catch_up_delegates_to_notification_handler(bot):
     with patch.object(
         bot.notification_handler, "catch_up", new=AsyncMock()
     ) as catch_up:
-        await bot.catch_up.callback(bot, ctx)
+        command = bot.get_command("catch_up")
+        assert command is not None
+        await command.callback(ctx)
     catch_up.assert_awaited_once_with(ctx)
 
 


### PR DESCRIPTION
## What changed

Registers `!help` and `!catch_up` through context-only closure callbacks, which delegate to the bot methods. This gives Discord.py the standalone callback shape it expects.

Adds regression coverage that invokes each registered callback with only `ctx`, matching Discord command dispatch.

## Root cause

The prior commands were decorator objects whose callbacks required `(self, ctx)` but were registered without a Cog. Discord.py invoked them as standalone commands, so every command failed before its handler ran.

## Validation

- `./venv/bin/ruff check .`
- `./venv/bin/ruff format --check actual_discord_bot/bot.py tests/unit_tests/test_bot.py`
- `./venv/bin/pytest tests/unit_tests` (137 passed)