### PR TITLE
Fix Actual client lifecycle between imports

### DIFF
--- a/actual_discord_bot/actual_connector.py
+++ b/actual_discord_bot/actual_connector.py
@@ -17,18 +17,21 @@ from actual_discord_bot.receipts.transaction import (
 class ActualConnector:
     def __init__(self, config: ActualConfig) -> None:
         self.config = config
-        self.actual_manager = Actual(
-            base_url=config.url,
-            password=config.password,
-            encryption_password=config.encryption_password,
-            file=config.file,
+
+    def _create_actual_manager(self) -> Actual:
+        """Create one disposable Actual client for a single import operation."""
+        return Actual(
+            base_url=self.config.url,
+            password=self.config.password,
+            encryption_password=self.config.encryption_password,
+            file=self.config.file,
         )
 
     def save_transaction(
         self,
         transaction_data: ActualTransactionData,
     ) -> Transactions:
-        with self.actual_manager as actual:
+        with self._create_actual_manager() as actual:
             # Receipt imports are expenses. Do not deduplicate a deposit against
             # an expense with the same absolute value.
             if transaction_data.amount < 0:
@@ -61,7 +64,7 @@ class ActualConnector:
         fallback_date: date | None = None,
     ) -> bool:
         """Create a split transaction from a parsed receipt."""
-        with self.actual_manager as actual:
+        with self._create_actual_manager() as actual:
             return create_receipt_split_transaction(
                 actual=actual,
                 receipt=receipt,

--- a/tests/unit_tests/test_actual_connector.py
+++ b/tests/unit_tests/test_actual_connector.py
@@ -21,17 +21,48 @@ def mock_actual_manager():
 
 
 @pytest.fixture
-def connector(mock_actual_manager):
+def mock_actual_factory(mock_actual_manager):
     with patch(
         "actual_discord_bot.actual_connector.Actual", return_value=mock_actual_manager
-    ):
-        return ActualConnector(
-            ActualConfig(url="http://test:5006", password="test", file="TestBudget")
-        )
+    ) as factory:
+        yield factory
+
+
+@pytest.fixture
+def connector(mock_actual_factory):
+    return ActualConnector(
+        ActualConfig(url="http://test:5006", password="test", file="TestBudget")
+    )
 
 
 class TestBankNotificationDeduplication:
     """Test that bank notifications don't create duplicates when receipts exist."""
+
+    def test_creates_a_fresh_client_for_each_transaction_save(
+        self, connector, mock_actual_factory
+    ):
+        """A closed Actual context manager must never be reused by a later import."""
+        transaction_data = ActualTransactionData(
+            date=date(2026, 5, 1),
+            account="Pekao",
+            amount=Decimal("-10.00"),
+            imported_payee="TestStore",
+        )
+
+        with (
+            patch(
+                "actual_discord_bot.actual_connector.find_matching_transaction",
+                return_value=None,
+            ),
+            patch(
+                "actual_discord_bot.actual_connector.create_transaction",
+                return_value=MagicMock(),
+            ),
+        ):
+            connector.save_transaction(transaction_data)
+            connector.save_transaction(transaction_data)
+
+        assert mock_actual_factory.call_count == 2
 
     def test_skips_creation_when_receipt_transaction_exists(
         self, connector, mock_actual_manager


### PR DESCRIPTION
## What changed

Creates a new `actualpy` `Actual` context manager for each transaction or receipt import instead of retaining one instance for the whole bot process.

Adds regression coverage for two consecutive transaction saves and keeps the `Actual` factory patch active for each test operation.

## Root cause

Leaving an `Actual` context closes its underlying HTTP client. The previous connector reused that same context manager, so the first successful import could leave all later imports failing with `RuntimeError: Cannot send a request, as the client has been closed.`

## Validation

- `./venv/bin/ruff check .`
- `./venv/bin/ruff format --check actual_discord_bot/actual_connector.py tests/unit_tests/test_actual_connector.py`
- `./venv/bin/pytest tests/unit_tests` (138 passed)