### PR TITLE
Add catch-up time lookback

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ an existing receipt.
 - **Transaction deduplication** — Prevents duplicate transactions when both a receipt and bank notification arrive for the same purchase
 - **Split transactions** — Each product line item becomes a sub-transaction in Actual Budget
 - **Discount handling** — Recognizes OBNIŻKA/RABAT/UPUST discount lines and includes them as negative sub-transactions
-- **Idempotent catch-up** — `!catch_up` command processes all unprocessed messages in the channel (skips already-reacted ones)
+- **Idempotent catch-up** — `!catch_up` processes all unprocessed messages in the channel (skips already-reacted ones), or accepts a lookback such as `!catch_up 2 days`
 - **In-channel guidance** — Posts a complete usage guide on startup and provides it on demand with `!help`
 - **Hot-reload** — Uses [cogwatch](https://github.com/robertwayne/cogwatch) only in the development Compose stack
 - **Dockerized deployment** — Full Docker Compose setup with bot, Actual server, and integration test services
@@ -288,7 +288,7 @@ without hot reload rather than blocking Discord startup.
 | Command | Description |
 |---------|-------------|
 | `!help` | Show the full channel guide, reactions, supported inputs, and commands |
-| `!catch_up` | Process all unprocessed messages in the notification channel |
+| `!catch_up [X hour(s)\|X day(s)\|X month(s)]` | Process all unprocessed messages in the notification channel, optionally limited to a lookback window |
 
 ### Discord Channel Setup
 

--- a/actual_discord_bot/bot.py
+++ b/actual_discord_bot/bot.py
@@ -1,7 +1,10 @@
 """Discord lifecycle, commands, and routing."""
 
 import asyncio
+import calendar
 import logging
+import re
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -20,6 +23,18 @@ if TYPE_CHECKING:
     from actual_discord_bot.channel_handlers.base import BaseChannelHandler
 
 LOGGER = logging.getLogger(__name__)
+
+CATCH_UP_TIME_DELTA_ERROR = (
+    "Error: Invalid time delta. Use X hour(s), X day(s), or X month(s)."
+)
+_CATCH_UP_TIME_DELTA_PATTERN = re.compile(
+    r"(?P<count>[1-9]\d*)\s+(?P<unit>hours?|days?|months?)",
+    re.IGNORECASE,
+)
+
+
+class CatchUpTimeDeltaError(ValueError):
+    """Raised when a catch-up time delta does not use a supported format."""
 
 
 class ActualDiscordBot(commands.Bot):
@@ -40,8 +55,10 @@ class ActualDiscordBot(commands.Bot):
         self.receipt_handler = receipt_handler
         self.hot_reload = hot_reload
 
-        async def catch_up_command(ctx: commands.Context) -> None:
-            await self._catch_up(ctx)
+        async def catch_up_command(
+            ctx: commands.Context, *, time_delta: str = ""
+        ) -> None:
+            await self._catch_up(ctx, time_delta)
 
         async def help_command(ctx: commands.Context) -> None:
             await self._help(ctx)
@@ -92,9 +109,18 @@ class ActualDiscordBot(commands.Bot):
                     )
                 return
 
-    async def _catch_up(self, ctx: commands.Context) -> None:
+    async def _catch_up(self, ctx: commands.Context, time_delta: str = "") -> None:
         """Retry notification messages that have not yet been imported."""
-        await self.notification_handler.catch_up(ctx)
+        try:
+            after = parse_catch_up_after(time_delta, discord.utils.utcnow())
+        except CatchUpTimeDeltaError:
+            await ctx.send(CATCH_UP_TIME_DELTA_ERROR)
+            return
+
+        if after is None:
+            await self.notification_handler.catch_up(ctx)
+            return
+        await self.notification_handler.catch_up(ctx, after=after)
 
     async def _help(self, ctx: commands.Context) -> None:
         """Show the guide or guides for the current channel."""
@@ -105,6 +131,34 @@ class ActualDiscordBot(commands.Bot):
             matching_handlers = [self.notification_handler]
         for handler in matching_handlers:
             await ctx.send(handler.help_message)
+
+
+def parse_catch_up_after(time_delta: str, now: datetime) -> datetime | None:
+    """
+    Return the earliest message time for a catch-up time delta.
+
+    An empty argument means to process the full channel history. Months are
+    calendar months, clamped to the last valid day of the target month.
+    """
+    if not time_delta.strip():
+        return None
+
+    match = _CATCH_UP_TIME_DELTA_PATTERN.fullmatch(time_delta.strip())
+    if match is None:
+        raise CatchUpTimeDeltaError
+
+    count = int(match["count"])
+    unit = match["unit"].lower()
+    if unit.startswith("hour"):
+        return now - timedelta(hours=count)
+    if unit.startswith("day"):
+        return now - timedelta(days=count)
+
+    target_month_index = now.year * 12 + now.month - 1 - count
+    target_year, target_month_index = divmod(target_month_index, 12)
+    target_month = target_month_index + 1
+    target_day = min(now.day, calendar.monthrange(target_year, target_month)[1])
+    return now.replace(year=target_year, month=target_month, day=target_day)
 
 
 async def main() -> None:

--- a/actual_discord_bot/channel_handlers/notifications.py
+++ b/actual_discord_bot/channel_handlers/notifications.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from datetime import datetime
 from enum import StrEnum
 
 import discord
@@ -30,14 +31,14 @@ Timestamp: <timestamp>
 ```
 I react with ✅ and reply with a summary when a transaction is created. If a notification cannot be read or imported, I react with ❌ and reply with the reason. Unexpected import errors are logged for troubleshooting.
 
-`!catch_up` skips messages marked with my ✅ or ❌. To request a retry, add any reaction to the message; I will try it again and remove that reaction afterwards, whether the retry succeeds or fails.
+`!catch_up` skips messages marked with my ✅ or ❌. Add a lookback such as `!catch_up 2 days` to process only recent messages. To request a retry, add any reaction to the message; I will try it again and remove that reaction afterwards, whether the retry succeeds or fails.
 
 **How notifications reach this channel**
 An administrator can create a Discord webhook for this channel in **Edit Channel → Integrations → Webhooks**. Its webhook URL is the special link that can post messages here—keep it private. On Android, an Automate flow can listen only for notifications from your bank app and send an HTTP POST to that URL, using `application/json` and the format above in the JSON `content` field. Never put your Discord bot token or Actual password in the flow or channel.
 
 **Commands**
 `!help` — show this notification guide
-`!catch_up` — retry messages in this channel that do not already have my ✅"""
+`!catch_up [X hour(s)|X day(s)|X month(s)]` — retry messages in this channel that do not already have my ✅"""
 
 
 class MessageHandlingResult(StrEnum):
@@ -102,7 +103,9 @@ class NotificationChannelHandler(BaseChannelHandler):
                 self.actual_connector.save_transaction, transaction_data
             )
 
-    async def catch_up(self, ctx: commands.Context) -> None:
+    async def catch_up(
+        self, ctx: commands.Context, *, after: datetime | None = None
+    ) -> None:
         """Retry unmarked messages and messages explicitly marked by a user."""
         if self.channel is None:
             await ctx.send(f"Error: Channel '{self.channel_name}' not found.")
@@ -110,7 +113,10 @@ class NotificationChannelHandler(BaseChannelHandler):
 
         processed_count = 0
         async with ctx.typing():
-            async for message in self.channel.history(limit=None):
+            history_arguments: dict[str, datetime | None] = {"limit": None}
+            if after is not None:
+                history_arguments["after"] = after
+            async for message in self.channel.history(**history_arguments):
                 if not self._should_retry(message):
                     continue
                 try:

--- a/tests/unit_tests/test_bot.py
+++ b/tests/unit_tests/test_bot.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
@@ -6,6 +7,11 @@ import pytest
 
 import actual_discord_bot.bot as bot_module
 from actual_discord_bot import ActualDiscordBot
+from actual_discord_bot.bot import (
+    CATCH_UP_TIME_DELTA_ERROR,
+    CatchUpTimeDeltaError,
+    parse_catch_up_after,
+)
 from actual_discord_bot.channel_handlers.notifications import (
     NOTIFICATION_HELP_MESSAGE,
     NotificationChannelHandler,
@@ -83,11 +89,15 @@ async def test_setup_hook_starts_hot_reload_when_source_tree_exists(
     watcher.start.assert_awaited_once()
 
 
-def test_registers_commands_with_context_only_callbacks(bot):
+def test_registers_commands_without_self_parameter(bot):
     for name in ("catch_up", "help"):
         command = bot.get_command(name)
         assert command is not None
         assert "self" not in command.params
+
+    catch_up = bot.get_command("catch_up")
+    assert catch_up is not None
+    assert "time_delta" in catch_up.params
 
 
 @pytest.mark.asyncio
@@ -190,6 +200,69 @@ async def test_catch_up_delegates_to_notification_handler(bot):
         assert command is not None
         await command.callback(ctx)
     catch_up.assert_awaited_once_with(ctx)
+
+
+@pytest.mark.asyncio
+async def test_catch_up_passes_valid_lookback_to_notification_handler(bot):
+    ctx = AsyncMock()
+    now = datetime(2026, 8, 2, 15, 30, tzinfo=UTC)
+    with (
+        patch.object(bot_module.discord.utils, "utcnow", return_value=now),
+        patch.object(bot.notification_handler, "catch_up", new=AsyncMock()) as catch_up,
+    ):
+        command = bot.get_command("catch_up")
+        assert command is not None
+        await command.callback(ctx, time_delta="2 days")
+
+    catch_up.assert_awaited_once_with(
+        ctx, after=datetime(2026, 7, 31, 15, 30, tzinfo=UTC)
+    )
+
+
+@pytest.mark.asyncio
+async def test_catch_up_rejects_invalid_lookback_without_processing(bot):
+    ctx = AsyncMock()
+    with patch.object(
+        bot.notification_handler, "catch_up", new=AsyncMock()
+    ) as catch_up:
+        command = bot.get_command("catch_up")
+        assert command is not None
+        await command.callback(ctx, time_delta="a few days")
+
+    ctx.send.assert_awaited_once_with(CATCH_UP_TIME_DELTA_ERROR)
+    catch_up.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("time_delta", "now", "expected"),
+    [
+        (
+            "1 hour",
+            datetime(2026, 8, 2, 15, 30, tzinfo=UTC),
+            datetime(2026, 8, 2, 14, 30, tzinfo=UTC),
+        ),
+        (
+            "12 DAYS",
+            datetime(2026, 8, 2, 15, 30, tzinfo=UTC),
+            datetime(2026, 7, 21, 15, 30, tzinfo=UTC),
+        ),
+        (
+            "6 months",
+            datetime(2026, 8, 31, 15, 30, tzinfo=UTC),
+            datetime(2026, 2, 28, 15, 30, tzinfo=UTC),
+        ),
+    ],
+)
+def test_parse_catch_up_after_supports_hours_days_and_calendar_months(
+    time_delta, now, expected
+):
+    assert parse_catch_up_after(time_delta, now) == expected
+
+
+@pytest.mark.parametrize("time_delta", ["0 hours", "two days", "1 week", "1day"])
+def test_parse_catch_up_after_rejects_invalid_time_deltas(time_delta):
+    with pytest.raises(CatchUpTimeDeltaError):
+        parse_catch_up_after(time_delta, datetime(2026, 8, 2, tzinfo=UTC))
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_notification_channel_handler.py
+++ b/tests/unit_tests/test_notification_channel_handler.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
@@ -128,3 +128,19 @@ async def test_catch_up_retries_user_marked_messages_and_removes_the_marker(hand
 
     handler.handle.assert_awaited_once_with(failed_import)
     failed_import.remove_reaction.assert_awaited_once_with("🔄", user)
+
+
+@pytest.mark.asyncio
+async def test_catch_up_limits_channel_history_to_the_requested_time(handler):
+    channel = AsyncMock(spec=discord.TextChannel)
+    handler.channel = channel
+    channel.history.return_value.__aiter__.return_value = []
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+    ctx.typing.return_value.__aenter__ = AsyncMock(return_value=None)
+    ctx.typing.return_value.__aexit__ = AsyncMock(return_value=None)
+    after = datetime(2026, 8, 1, tzinfo=UTC)
+
+    await handler.catch_up(ctx, after=after)
+
+    channel.history.assert_called_once_with(limit=None, after=after)


### PR DESCRIPTION
## Summary

- add optional `!catch_up X hour(s)|day(s)|month(s)` lookbacks
- preserve full-channel processing when no argument is supplied
- reject invalid lookbacks before any message history is processed
- document the command and add unit coverage

## Behavior

Months use calendar-month subtraction and clamp to the last valid day of the target month.

## Validation

- `ruff check actual_discord_bot/bot.py actual_discord_bot/channel_handlers/notifications.py tests/unit_tests/test_bot.py tests/unit_tests/test_notification_channel_handler.py`
- `pytest tests/unit_tests` (148 passed)