### PR TITLE
Add moderator clear channel command

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ desired. This address is intentionally available only while connected to the LAN
 3. Copy the bot token into `DISCORD_TOKEN` in `deployment/lan/.env`. Treat it like
    a password and never commit the `.env` file.
 4. In the OAuth2 URL Generator, select the `bot` scope and grant **View Channels**,
-   **Send Messages**, **Read Message History**, **Add Reactions**, and
+   **Send Messages**, **Read Message History**, **Manage Messages**, **Add Reactions**, and
    **Attach Files**. Open the generated URL and invite the bot to your server.
 5. Create `bank-notifications` and, optionally, `receipts` and `bank-imports`
    text channels. Make `bank-imports` private: statements are sensitive. Give the
@@ -324,6 +324,7 @@ without hot reload rather than blocking Discord startup.
 |---------|-------------|
 | `!help` | Show the full channel guide, reactions, supported inputs, and commands |
 | `!catch_up [X hour(s)\|X day(s)\|X month(s)]` | Process all unprocessed messages in the notification channel, optionally limited to a lookback window |
+| `!clear_channel` | Permanently delete all deletable messages in the current watched channel, then report the count; requires the caller and bot to have **Manage Messages** |
 | `!make_schedule [X day(s)\|X week(s)\|X month(s)\|X year(s)]` | Reply to a bank notification marked ✅ to create an idempotent, never-ending schedule; defaults to every month and requires manual approval |
 
 `!make_schedule` uses the original transaction date, exact signed amount, account,

--- a/actual_discord_bot/bot.py
+++ b/actual_discord_bot/bot.py
@@ -3,6 +3,7 @@
 import asyncio
 import calendar
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -37,6 +38,16 @@ LOGGER = logging.getLogger(__name__)
 CATCH_UP_TIME_DELTA_ERROR = (
     "Error: Invalid time delta. Use X hour(s), X day(s), or X month(s)."
 )
+BULK_DELETE_SAFE_AGE = timedelta(days=13, hours=23)
+MAX_BULK_DELETE_MESSAGES = 100
+
+
+@dataclass(frozen=True)
+class ClearChannelResult:
+    """Outcome of a watched-channel history deletion."""
+
+    deleted_count: int
+    incomplete: bool
 
 
 class CatchUpTimeDeltaError(TimeDeltaError):
@@ -62,6 +73,7 @@ class ActualDiscordBot(commands.Bot):
         self.receipt_handler = receipt_handler
         self.bank_import_handler = bank_import_handler
         self.hot_reload = hot_reload
+        self._clear_channel_locks: dict[int, asyncio.Lock] = {}
 
         async def catch_up_command(
             ctx: commands.Context, *, time_delta: str = ""
@@ -71,12 +83,16 @@ class ActualDiscordBot(commands.Bot):
         async def help_command(ctx: commands.Context) -> None:
             await self._help(ctx)
 
+        async def clear_channel_command(ctx: commands.Context) -> None:
+            await self._clear_channel(ctx)
+
         async def make_schedule_command(
             ctx: commands.Context, *, time_delta: str = ""
         ) -> None:
             await self._make_schedule(ctx, time_delta)
 
         self.add_command(commands.Command(catch_up_command, name="catch_up"))
+        self.add_command(commands.Command(clear_channel_command, name="clear_channel"))
         self.add_command(commands.Command(help_command, name="help"))
         self.add_command(commands.Command(make_schedule_command, name="make_schedule"))
         self.handlers: tuple[BaseChannelHandler, ...] = tuple(
@@ -146,6 +162,37 @@ class ActualDiscordBot(commands.Bot):
         for handler in matching_handlers:
             await ctx.send(handler.help_message)
 
+    async def _clear_channel(self, ctx: commands.Context) -> None:
+        """Delete every deletable message in the invoking watched channel."""
+        if not any(handler.matches(ctx.channel) for handler in self.handlers):
+            await ctx.send(
+                "Error: This command can only be used in a configured watched channel."
+            )
+            return
+
+        if not isinstance(ctx.channel, discord.TextChannel) or not isinstance(
+            ctx.author, discord.Member
+        ):
+            await ctx.send("Error: This command can only be used in a server text channel.")
+            return
+
+        if not ctx.channel.permissions_for(ctx.author).manage_messages:
+            await ctx.send(
+                "Error: You need the Manage Messages permission to clear this channel."
+            )
+            return
+
+        lock = self._clear_channel_locks.setdefault(ctx.channel.id, asyncio.Lock())
+        async with lock:
+            result = await delete_channel_history(ctx.channel)
+
+        if result.incomplete:
+            await ctx.send(
+                f"Channel clear incomplete. Deleted {result.deleted_count} messages."
+            )
+            return
+        await ctx.send(f"Channel cleared. Deleted {result.deleted_count} messages.")
+
     async def _make_schedule(self, ctx: commands.Context, time_delta: str = "") -> None:
         """Create a recurring schedule from a successfully imported reply target."""
         try:
@@ -156,6 +203,48 @@ class ActualDiscordBot(commands.Bot):
             )
             return
         await self.notification_handler.make_schedule(ctx, recurrence)
+
+
+async def delete_channel_history(channel: discord.TextChannel) -> ClearChannelResult:
+    """Delete channel history while retaining an accurate success count."""
+    deleted_count = 0
+    skipped_message = False
+    recent_messages: list[discord.Message] = []
+    bulk_delete_after = discord.utils.utcnow() - BULK_DELETE_SAFE_AGE
+
+    async def delete_recent_messages() -> None:
+        nonlocal deleted_count
+        if not recent_messages:
+            return
+        if len(recent_messages) == 1:
+            await recent_messages[0].delete()
+        else:
+            await channel.delete_messages(list(recent_messages))
+        deleted_count += len(recent_messages)
+        recent_messages.clear()
+
+    try:
+        async for message in channel.history(limit=None):
+            if not message.type.is_deletable():
+                skipped_message = True
+                continue
+
+            if message.created_at <= bulk_delete_after:
+                await delete_recent_messages()
+                await message.delete()
+                deleted_count += 1
+                continue
+
+            recent_messages.append(message)
+            if len(recent_messages) == MAX_BULK_DELETE_MESSAGES:
+                await delete_recent_messages()
+
+        await delete_recent_messages()
+    except (discord.Forbidden, discord.HTTPException):
+        LOGGER.exception("Could not completely clear Discord channel %s", channel.id)
+        return ClearChannelResult(deleted_count, incomplete=True)
+
+    return ClearChannelResult(deleted_count, incomplete=skipped_message)
 
 
 def parse_catch_up_after(time_delta: str, now: datetime) -> datetime | None:

--- a/actual_discord_bot/channel_handlers/bank_imports.py
+++ b/actual_discord_bot/channel_handlers/bank_imports.py
@@ -40,8 +40,9 @@ Post exactly one bank-statement CSV, retaining the filename supplied by your ban
 
 I will select an unambiguous open Actual account automatically, or ask the uploader to choose one. Existing transactions are never changed; the reply contains only aggregate import counts. Bank statements are sensitive: keep this channel private and visible only to people you trust.
 
-**Command**
-`!help` — show this guide"""
+**Commands**
+`!help` — show this guide
+`!clear_channel` — permanently delete all deletable messages in this watched channel. Requires your Manage Messages permission."""
 
 
 class AccountSelectionView(discord.ui.View):

--- a/actual_discord_bot/channel_handlers/notifications.py
+++ b/actual_discord_bot/channel_handlers/notifications.py
@@ -47,7 +47,8 @@ An administrator can create a Discord webhook for this channel in **Edit Channel
 **Commands**
 `!help` — show this notification guide
 `!catch_up [X hour(s)|X day(s)|X month(s)]` — retry messages in this channel that do not already have my ✅
-`!make_schedule [X day(s)|X week(s)|X month(s)|X year(s)]` — reply to a notification I marked ✅ to create a manual-approval recurring schedule. It defaults to monthly."""
+`!make_schedule [X day(s)|X week(s)|X month(s)|X year(s)]` — reply to a notification I marked ✅ to create a manual-approval recurring schedule. It defaults to monthly.
+`!clear_channel` — permanently delete all deletable messages in this watched channel. Requires your Manage Messages permission."""
 
 
 class MessageHandlingResult(StrEnum):

--- a/actual_discord_bot/channel_handlers/receipts.py
+++ b/actual_discord_bot/channel_handlers/receipts.py
@@ -32,8 +32,9 @@ Attach one JPG, JPEG, PNG, WebP, or PDF receipt to this channel (maximum 10 MB).
 
 I react with ✅ and reply with a summary when a transaction is created. ⚠️ means I found a likely duplicate or the extracted item totals did not match the receipt total, so nothing was saved. ❌ means processing failed. Image text is read with OCR and may be imperfect; use a sharp, evenly lit, straight-on photo and always verify the result in Actual Budget. I ignore ordinary text and unsupported attachments.
 
-**Command**
+**Commands**
 `!help` — show this receipt guide
+`!clear_channel` — permanently delete all deletable messages in this watched channel. Requires your Manage Messages permission.
 
 Receipts may contain sensitive information, so only post them in a private channel that is visible to people you trust."""
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,13 +82,17 @@ Bank CSV handling is ordered before receipt and notification handling. Receipt
 handling is ordered before notifications. If workflows share a channel, a CSV is
 processed only by the bank-import path and a supported receipt attachment only by
 the receipt path; other non-command text can be processed as a notification.
-`!help` sends all guides that apply to the current channel. `!catch_up` belongs
-to the notification handler and retries messages without the bot's success
-reaction; it never scans historical statement attachments. `!make_schedule`
-also belongs to that handler. It must be sent as a reply in the configured bank
-notification channel and accepts an optional positive `X day(s)`, `X week(s)`,
-`X month(s)`, or `X year(s)` recurrence; no argument means monthly. Invalid
-duration text does not reach the Actual connector.
+`!help` sends all guides that apply to the current channel. `!clear_channel` is
+a common moderator command available only in bound watched text channels; it
+deletes the command and all other deletable messages before reporting the count.
+It batches recent messages and deletes older history individually because Discord
+does not support bulk deletion beyond two weeks. `!catch_up` belongs to the
+notification handler and retries messages without the bot's success reaction; it
+never scans historical statement attachments. `!make_schedule` also belongs to
+that handler. It must be sent as a reply in the configured bank notification
+channel and accepts an optional positive `X day(s)`, `X week(s)`, `X month(s)`,
+or `X year(s)` recurrence; no argument means monthly. Invalid duration text does
+not reach the Actual connector.
 
 Unexpected handler exceptions are logged at the bot boundary so one malformed
 message cannot break subsequent routing. Feature handlers translate expected

--- a/tests/unit_tests/test_bot.py
+++ b/tests/unit_tests/test_bot.py
@@ -1,5 +1,6 @@
+import asyncio
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
@@ -9,8 +10,11 @@ import pytest
 import actual_discord_bot.bot as bot_module
 from actual_discord_bot import ActualDiscordBot
 from actual_discord_bot.bot import (
+    BULK_DELETE_SAFE_AGE,
     CATCH_UP_TIME_DELTA_ERROR,
     CatchUpTimeDeltaError,
+    ClearChannelResult,
+    delete_channel_history,
     parse_catch_up_after,
 )
 from actual_discord_bot.channel_handlers.bank_imports import BankImportChannelHandler
@@ -29,6 +33,23 @@ def _channel(identifier: int, name: str):
     channel.id = identifier
     channel.name = name
     return channel
+
+
+def _history(messages):
+    async def iterator():
+        for message in messages:
+            yield message
+
+    return iterator()
+
+
+def _message(identifier: int, created_at: datetime, *, deletable: bool = True):
+    message = MagicMock(spec=discord.Message)
+    message.id = identifier
+    message.created_at = created_at
+    message.type.is_deletable.return_value = deletable
+    message.delete = AsyncMock()
+    return message
 
 
 @pytest.mark.asyncio
@@ -92,7 +113,7 @@ async def test_setup_hook_starts_hot_reload_when_source_tree_exists(
 
 
 def test_registers_commands_without_self_parameter(bot):
-    for name in ("catch_up", "help", "make_schedule"):
+    for name in ("catch_up", "clear_channel", "help", "make_schedule"):
         command = bot.get_command(name)
         assert command is not None
         assert "self" not in command.params
@@ -103,6 +124,207 @@ def test_registers_commands_without_self_parameter(bot):
     make_schedule = bot.get_command("make_schedule")
     assert make_schedule is not None
     assert "time_delta" in make_schedule.params
+
+
+@pytest.mark.asyncio
+async def test_clear_channel_rejects_an_unwatched_channel(bot):
+    ctx = AsyncMock()
+    ctx.channel = _channel(10, "unwatched")
+
+    command = bot.get_command("clear_channel")
+    assert command is not None
+    await command.callback(ctx)
+
+    ctx.send.assert_awaited_once_with(
+        "Error: This command can only be used in a configured watched channel."
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_channel_requires_caller_manage_messages_permission(bot):
+    channel = _channel(1, "bank-notifications")
+    bot.notification_handler.channel = channel
+    ctx = AsyncMock()
+    ctx.channel = channel
+    ctx.author = MagicMock(spec=discord.Member)
+    channel.permissions_for.return_value.manage_messages = False
+
+    command = bot.get_command("clear_channel")
+    assert command is not None
+    await command.callback(ctx)
+
+    ctx.send.assert_awaited_once_with(
+        "Error: You need the Manage Messages permission to clear this channel."
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_channel_rejects_a_non_text_watched_channel(bot):
+    channel = MagicMock()
+    channel.id = 1
+    bot.notification_handler.channel = channel
+    ctx = AsyncMock()
+    ctx.channel = channel
+    ctx.author = MagicMock(spec=discord.Member)
+
+    command = bot.get_command("clear_channel")
+    assert command is not None
+    await command.callback(ctx)
+
+    ctx.send.assert_awaited_once_with(
+        "Error: This command can only be used in a server text channel."
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_channel_deletes_watched_history_and_reports_count(bot):
+    channel = _channel(1, "bank-notifications")
+    bot.notification_handler.channel = channel
+    ctx = AsyncMock()
+    ctx.channel = channel
+    ctx.author = MagicMock(spec=discord.Member)
+    channel.permissions_for.return_value.manage_messages = True
+
+    with patch.object(
+        bot_module,
+        "delete_channel_history",
+        new=AsyncMock(return_value=ClearChannelResult(3, incomplete=False)),
+    ) as delete_history:
+        command = bot.get_command("clear_channel")
+        assert command is not None
+        await command.callback(ctx)
+
+    delete_history.assert_awaited_once_with(channel)
+    ctx.send.assert_awaited_once_with("Channel cleared. Deleted 3 messages.")
+
+
+@pytest.mark.asyncio
+async def test_clear_channel_reports_a_partial_result(bot):
+    channel = _channel(1, "bank-notifications")
+    bot.notification_handler.channel = channel
+    ctx = AsyncMock()
+    ctx.channel = channel
+    ctx.author = MagicMock(spec=discord.Member)
+    channel.permissions_for.return_value.manage_messages = True
+
+    with patch.object(
+        bot_module,
+        "delete_channel_history",
+        new=AsyncMock(return_value=ClearChannelResult(2, incomplete=True)),
+    ):
+        command = bot.get_command("clear_channel")
+        assert command is not None
+        await command.callback(ctx)
+
+    ctx.send.assert_awaited_once_with("Channel clear incomplete. Deleted 2 messages.")
+
+
+@pytest.mark.asyncio
+async def test_clear_channel_serializes_deletion_in_one_channel(bot):
+    channel = _channel(1, "bank-notifications")
+    bot.notification_handler.channel = channel
+    first_deletion_started = asyncio.Event()
+    release_first_deletion = asyncio.Event()
+    calls = 0
+
+    async def delete_history(_channel):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_deletion_started.set()
+            await release_first_deletion.wait()
+        return ClearChannelResult(0, incomplete=False)
+
+    def context():
+        ctx = AsyncMock()
+        ctx.channel = channel
+        ctx.author = MagicMock(spec=discord.Member)
+        return ctx
+
+    channel.permissions_for.return_value.manage_messages = True
+    first_context = context()
+    second_context = context()
+    command = bot.get_command("clear_channel")
+    assert command is not None
+
+    with patch.object(bot_module, "delete_channel_history", new=delete_history):
+        first_task = asyncio.create_task(command.callback(first_context))
+        await first_deletion_started.wait()
+        second_task = asyncio.create_task(command.callback(second_context))
+        await asyncio.sleep(0)
+        assert calls == 1
+        release_first_deletion.set()
+        await asyncio.gather(first_task, second_task)
+
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_channel_history_batches_recent_messages_and_deletes_old_ones(bot):
+    now = datetime(2026, 8, 2, 15, 30, tzinfo=UTC)
+    channel = _channel(1, "bank-notifications")
+    recent_messages = [
+        _message(1, now - timedelta(days=1)),
+        _message(2, now - timedelta(days=2)),
+    ]
+    old_message = _message(3, now - timedelta(days=15))
+    channel.history.return_value = _history([*recent_messages, old_message])
+
+    with patch.object(bot_module.discord.utils, "utcnow", return_value=now):
+        result = await delete_channel_history(channel)
+
+    assert result == ClearChannelResult(3, incomplete=False)
+    channel.delete_messages.assert_awaited_once_with(recent_messages)
+    old_message.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_channel_history_splits_batches_at_one_hundred_messages(bot):
+    now = datetime(2026, 8, 2, 15, 30, tzinfo=UTC)
+    channel = _channel(1, "bank-notifications")
+    messages = [_message(index, now) for index in range(101)]
+    channel.history.return_value = _history(messages)
+
+    with patch.object(bot_module.discord.utils, "utcnow", return_value=now):
+        result = await delete_channel_history(channel)
+
+    assert result == ClearChannelResult(101, incomplete=False)
+    assert len(channel.delete_messages.await_args.args[0]) == 100
+    messages[-1].delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_channel_history_reports_non_deletable_messages_as_incomplete(bot):
+    now = datetime(2026, 8, 2, 15, 30, tzinfo=UTC)
+    channel = _channel(1, "bank-notifications")
+    deletable = _message(1, now)
+    non_deletable = _message(2, now, deletable=False)
+    channel.history.return_value = _history([deletable, non_deletable])
+
+    with patch.object(bot_module.discord.utils, "utcnow", return_value=now):
+        result = await delete_channel_history(channel)
+
+    assert result == ClearChannelResult(1, incomplete=True)
+    deletable.delete.assert_awaited_once()
+    non_deletable.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_channel_history_reports_successful_deletions_before_an_api_error(bot):
+    now = datetime(2026, 8, 2, 15, 30, tzinfo=UTC)
+    channel = _channel(1, "bank-notifications")
+    old_message = _message(1, now - BULK_DELETE_SAFE_AGE - timedelta(days=1))
+    failing_message = _message(2, now - BULK_DELETE_SAFE_AGE - timedelta(days=2))
+    failing_message.delete.side_effect = discord.HTTPException(
+        MagicMock(status=500, reason="server error"), "server error"
+    )
+    channel.history.return_value = _history([old_message, failing_message])
+
+    with patch.object(bot_module.discord.utils, "utcnow", return_value=now):
+        result = await delete_channel_history(channel)
+
+    assert result == ClearChannelResult(1, incomplete=True)
+    old_message.delete.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `!clear_channel` as a common command for configured watched text channels
- require the caller's effective Manage Messages permission and serialize concurrent clears per channel
- bulk-delete recent messages, individually delete older messages, and accurately report completed or partial deletion counts
- document the command and required Discord permissions

## Validation
- `pytest tests/unit_tests/` (214 passed)
- `ruff check actual_discord_bot/bot.py actual_discord_bot/channel_handlers/notifications.py actual_discord_bot/channel_handlers/receipts.py actual_discord_bot/channel_handlers/bank_imports.py tests/unit_tests/test_bot.py`
- `git diff --check`

`docs/SCHEDULES_PLAN.md` was pre-existing and intentionally excluded.