### PR TITLE
Bump Actual Server to 26.8.0

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Start Actual Server
       run: |
-        docker run -d --name actual_server -p 12012:5006 actualbudget/actual-server:26.7.0
+        docker run -d --name actual_server -p 12012:5006 actualbudget/actual-server:26.8.0
       env:
         ACTUAL_PASSWORD: test
 

--- a/deployment/lan/compose.yml
+++ b/deployment/lan/compose.yml
@@ -2,7 +2,7 @@ name: actual-budget-home
 
 services:
   actual_server:
-    image: docker.io/actualbudget/actual-server:26.4.0
+    image: docker.io/actualbudget/actual-server:26.8.0
     restart: unless-stopped
     ports:
       - "12012:5006"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     command: python -u -m actual_discord_bot.bot
 
   actual_server:
-    image: docker.io/actualbudget/actual-server:26.7.0
+    image: docker.io/actualbudget/actual-server:26.8.0
     ports:
       - '12012:5006'
     volumes:
@@ -40,7 +40,7 @@ services:
       start_period: 20s
 
   test_actual_server:
-    image: docker.io/actualbudget/actual-server:26.7.0
+    image: docker.io/actualbudget/actual-server:26.8.0
     ports:
       - '12013:5006'
     profiles:


### PR DESCRIPTION
## Summary

Updates every pinned Actual Server reference to `26.8.0`:

- primary Docker Compose runtime and test service
- LAN deployment Compose file
- GitHub Actions unit-test server

`actualpy` was checked against PyPI and is already at its latest release, `0.22.3`.

## Validation

- `docker compose -f docker-compose.yml config --quiet`
- `docker compose -f deployment/lan/compose.yml config --quiet`
- `poetry run pytest tests/unit_tests/` — 221 passed
- Isolated Actual Server `26.8.0` integration run — 9 passed