### PR TITLE
Fix receipt OCR and error reporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,12 @@ WORKDIR /app
 
 FROM python-base AS production
 
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+    tesseract-ocr \
+    tesseract-ocr-pol \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder-base $VENV_PATH $VENV_PATH
 COPY --from=builder-base $PYSETUP_PATH/dist .
 # The builder virtualenv already contains the lockfile-resolved VCS dependency.

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ OCR_TESSERACT_PSM=6                     # Tesseract page segmentation mode (defa
 | `DISCORD_BANK_IMPORT_CHANNEL` | No | Private channel for one-file bank CSV imports |
 | `DISCORD_RECEIPT_CHANNEL` | No | Name of the channel for receipt photos/PDFs |
 | `DISCORD_HOT_RELOAD` | No | Enable source watching in a development checkout (default: `false`) |
-| `DISCORD_SHOW_ERROR_TRACEBACKS` | No | Include formatted tracebacks in Discord replies for unexpected notification and schedule errors (default: `true`); set to `false` for shared channels |
+| `DISCORD_SHOW_ERROR_TRACEBACKS` | No | Include formatted tracebacks in Discord replies for unexpected notification, receipt, and schedule errors (default: `true`); set to `false` for shared channels |
 | `BANK_NOTIFICATION_TIMEZONE` | No | IANA timezone used for forwarded notification timestamps and schedules (default: `Europe/Warsaw`) |
 | `BANK_IMPORT_TIMEZONE` | No | IANA timezone for bank-import calendar months (default: `Europe/Warsaw`) |
 | `ACTUAL_URL` | Yes | Actual Budget server URL |

--- a/actual_discord_bot/bot.py
+++ b/actual_discord_bot/bot.py
@@ -301,6 +301,7 @@ async def main() -> None:
             actual_connector,
             receipt_processor,
             actual_write_lock=actual_write_lock,
+            show_error_tracebacks=discord_config.show_error_tracebacks,
         )
     bank_import_handler = None
     bank_import_channel = getattr(discord_config, "bank_import_channel", "")

--- a/actual_discord_bot/channel_handlers/base.py
+++ b/actual_discord_bot/channel_handlers/base.py
@@ -1,6 +1,7 @@
 """Common lifecycle behavior for configured Discord channels."""
 
 import logging
+import traceback
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 
@@ -8,6 +9,7 @@ import discord
 
 LOGGER = logging.getLogger(__name__)
 SUCCESS_REACTION = "✅"
+MAX_DISCORD_MESSAGE_LENGTH = 2_000
 
 
 class BaseChannelHandler(ABC):
@@ -78,3 +80,27 @@ class BaseChannelHandler(ABC):
     @abstractmethod
     async def handle(self, message: discord.Message) -> object:
         """Handle a message accepted by this channel workflow."""
+
+
+def format_unexpected_error(
+    message: str, error: BaseException, *, show_traceback: bool
+) -> str:
+    """Return a Discord-safe unexpected-error message, optionally with its traceback."""
+    if not show_traceback:
+        return f"{message} The error has been logged."
+
+    prefix = f"{message}\n**Traceback**\n```py\n"
+    suffix = "\n```"
+    formatted_traceback = (
+        "".join(traceback.format_exception(error)).strip().replace("```", "``\u200b`")
+    )
+    max_traceback_length = MAX_DISCORD_MESSAGE_LENGTH - len(prefix) - len(suffix)
+    if len(formatted_traceback) > max_traceback_length:
+        truncation_notice = "\n... traceback truncated"
+        formatted_traceback = (
+            formatted_traceback[
+                : max_traceback_length - len(truncation_notice)
+            ].rstrip()
+            + truncation_notice
+        )
+    return f"{prefix}{formatted_traceback}{suffix}"

--- a/actual_discord_bot/channel_handlers/notifications.py
+++ b/actual_discord_bot/channel_handlers/notifications.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import traceback
 from datetime import UTC, datetime
 from decimal import Decimal
 from enum import StrEnum
@@ -21,6 +20,7 @@ from actual_discord_bot.bank_notifications.base_notification import BaseNotifica
 from actual_discord_bot.channel_handlers.base import (
     SUCCESS_REACTION,
     BaseChannelHandler,
+    format_unexpected_error,
 )
 from actual_discord_bot.dataclasses_definitions import ActualTransactionData
 from actual_discord_bot.errors import ParseNotificationError, ScheduleSourceNotFound
@@ -29,7 +29,6 @@ from actual_discord_bot.schedules import ScheduleRecurrence
 LOGGER = logging.getLogger(__name__)
 ERROR_REACTION = "❌"
 DEFAULT_NOTIFICATION_TIMEZONE = ZoneInfo("Europe/Warsaw")
-MAX_DISCORD_MESSAGE_LENGTH = 2_000
 
 NOTIFICATION_HELP_MESSAGE = """👋 **Hello! I am your Actual Budget notification assistant.**
 
@@ -98,7 +97,7 @@ class NotificationChannelHandler(BaseChannelHandler):
             LOGGER.exception("Error importing bank notification message %s", message.id)
             await message.add_reaction(ERROR_REACTION)
             await message.reply(
-                _format_unexpected_error(
+                format_unexpected_error(
                     "An unexpected error occurred while importing the notification.",
                     error,
                     show_traceback=self.show_error_tracebacks,
@@ -199,7 +198,7 @@ class NotificationChannelHandler(BaseChannelHandler):
                 source_message.id,
             )
             await ctx.reply(
-                _format_unexpected_error(
+                format_unexpected_error(
                     "An unexpected error occurred while creating the schedule.",
                     error,
                     show_traceback=self.show_error_tracebacks,
@@ -365,27 +364,3 @@ def _format_schedule_summary(schedule_data: ActualScheduleData) -> str:
         f"{abs(schedule_data.amount)} PLN · Account: **{schedule_data.account}**\n"
         "Transactions require manual approval."
     )
-
-
-def _format_unexpected_error(
-    message: str, error: BaseException, *, show_traceback: bool
-) -> str:
-    """Return a Discord-safe unexpected-error message, optionally with its traceback."""
-    if not show_traceback:
-        return f"{message} The error has been logged."
-
-    prefix = f"{message}\n**Traceback**\n```py\n"
-    suffix = "\n```"
-    formatted_traceback = "".join(traceback.format_exception(error)).strip().replace(
-        "```", "``\u200b`"
-    )
-    max_traceback_length = MAX_DISCORD_MESSAGE_LENGTH - len(prefix) - len(suffix)
-    if len(formatted_traceback) > max_traceback_length:
-        truncation_notice = "\n... traceback truncated"
-        formatted_traceback = (
-            formatted_traceback[
-                : max_traceback_length - len(truncation_notice)
-            ].rstrip()
-            + truncation_notice
-        )
-    return f"{prefix}{formatted_traceback}{suffix}"

--- a/actual_discord_bot/channel_handlers/receipts.py
+++ b/actual_discord_bot/channel_handlers/receipts.py
@@ -11,6 +11,7 @@ from actual_discord_bot.actual_connector import ActualConnector
 from actual_discord_bot.channel_handlers.base import (
     SUCCESS_REACTION,
     BaseChannelHandler,
+    format_unexpected_error,
 )
 from actual_discord_bot.receipts.models import ParsedReceipt, ReceiptItem
 from actual_discord_bot.receipts.processor import (
@@ -49,11 +50,13 @@ class ReceiptChannelHandler(BaseChannelHandler):
         receipt_processor: ReceiptProcessor,
         processing_slots: int = 1,
         actual_write_lock: asyncio.Lock | None = None,
+        show_error_tracebacks: bool = True,
     ) -> None:
         super().__init__(channel_name, RECEIPT_HELP_MESSAGE)
         self.actual_connector = actual_connector
         self.receipt_processor = receipt_processor
         self.actual_write_lock = actual_write_lock
+        self.show_error_tracebacks = show_error_tracebacks
         self.processing_slots = asyncio.Semaphore(processing_slots)
 
     def accepts(self, message: discord.Message) -> bool:
@@ -75,11 +78,15 @@ class ReceiptChannelHandler(BaseChannelHandler):
         except ReceiptProcessingError as error:
             await message.add_reaction(REACTION_ERROR)
             await message.reply(f"Could not process receipt: {error}")
-        except Exception:
+        except Exception as error:
             LOGGER.exception("Error processing receipt from message %s", message.id)
             await message.add_reaction(REACTION_ERROR)
             await message.reply(
-                "An unexpected error occurred while processing the receipt."
+                format_unexpected_error(
+                    "An unexpected error occurred while processing the receipt.",
+                    error,
+                    show_traceback=self.show_error_tracebacks,
+                )
             )
 
     async def _process_attachment(

--- a/actual_discord_bot/receipts/parser.py
+++ b/actual_discord_bot/receipts/parser.py
@@ -99,6 +99,14 @@ PRICE_ONLY_RE = re.compile(
 # Standalone price line (used in PDF digital receipts)
 STANDALONE_PRICE_RE = re.compile(r"^-?[\d]+[.,]\d{2}$")
 
+# OCR from app screenshots places the product name and price on the same line.
+DIGITAL_PRODUCT_LINE_RE = re.compile(
+    r"^(?P<name>.+?\S)\s+(?P<total_price>-?[\d]+[.,]\d{2})$"
+)
+DIGITAL_TOTAL_LINE_RE = re.compile(
+    r"^Suma(?:\s+\S+)*\s+(?P<total>[\d]+[.,]\d{2})$", re.IGNORECASE
+)
+
 PARTIAL_PRODUCT_LINE_RE = re.compile(
     r"^.+\s+[\d]+[.,]?\d*\s*[x\N{MULTIPLICATION SIGN}*]\s*-?[\d]+[.,]\d{2}$",
 )
@@ -210,9 +218,15 @@ class ReceiptParser:
 
     def _extract_digital_store_name(self, lines: list[str]) -> str:
         """Extract store name from digital receipt header."""
+        after_summary = False
         for line in lines:
             stripped = _normalize_ocr_line(line.strip())
-            if stripped and "Podsumowanie" not in stripped and "Cena" not in stripped:
+            if "Podsumowanie" in stripped:
+                after_summary = True
+                continue
+            if after_summary and "Cena" in stripped:
+                break
+            if after_summary and stripped:
                 return stripped
         return "Unknown"
 
@@ -237,9 +251,12 @@ class ReceiptParser:
                 i += 1
                 continue
 
+            if total_match := DIGITAL_TOTAL_LINE_RE.match(stripped):
+                total = _parse_decimal(total_match.group("total"))
+                break
+
             if stripped.lower() == "suma":
-                if items:
-                    total = items.pop().total_price
+                total = items.pop().total_price if items else total
                 i += 1
                 continue
 
@@ -251,11 +268,21 @@ class ReceiptParser:
                 result = self._try_consume_name(lines, i, price, items)
                 if result is not None:
                     i, found_total = result
-                    if found_total is not None:
-                        total = found_total
+                    total = found_total if found_total is not None else total
                     continue
                 i += 1
                 continue
+
+            if product_match := DIGITAL_PRODUCT_LINE_RE.match(stripped):
+                price = _parse_decimal(product_match.group("total_price"))
+                items.append(
+                    ReceiptItem(
+                        name=product_match.group("name"),
+                        quantity=Decimal("1"),
+                        unit_price=price,
+                        total_price=price,
+                    )
+                )
 
             i += 1
 

--- a/tests/unit_tests/test_bot.py
+++ b/tests/unit_tests/test_bot.py
@@ -586,6 +586,7 @@ async def test_main_configures_optional_receipt_stack(receipt_channel):
     if receipt_channel:
         processor.assert_called_once()
         assert discord_bot.call_args.args[1] is not None
+        assert discord_bot.call_args.args[1].show_error_tracebacks is False
     else:
         processor.assert_not_called()
         assert discord_bot.call_args.args[1] is None

--- a/tests/unit_tests/test_notification_channel_handler.py
+++ b/tests/unit_tests/test_notification_channel_handler.py
@@ -5,11 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
+from actual_discord_bot.channel_handlers.base import format_unexpected_error
 from actual_discord_bot.channel_handlers.notifications import (
     ERROR_REACTION,
     MessageHandlingResult,
     NotificationChannelHandler,
-    _format_unexpected_error,
 )
 from actual_discord_bot.dataclasses_definitions import ActualTransactionData
 from actual_discord_bot.errors import ParseNotificationError
@@ -103,7 +103,7 @@ async def test_unexpected_error_hides_the_traceback_when_disabled():
 
 
 def test_unexpected_error_traceback_fits_in_a_discord_message():
-    reply = _format_unexpected_error(
+    reply = format_unexpected_error(
         "An unexpected error occurred.", RuntimeError("x" * 3_000), show_traceback=True
     )
 
@@ -113,7 +113,7 @@ def test_unexpected_error_traceback_fits_in_a_discord_message():
 
 
 def test_unexpected_error_escapes_markdown_fences_in_the_traceback():
-    reply = _format_unexpected_error(
+    reply = format_unexpected_error(
         "An unexpected error occurred.", RuntimeError("```"), show_traceback=True
     )
 

--- a/tests/unit_tests/test_receipt_channel_handler.py
+++ b/tests/unit_tests/test_receipt_channel_handler.py
@@ -93,3 +93,42 @@ async def test_processing_error_is_translated_to_discord_reply(handler, message)
     await handler.handle(message)
     message.add_reaction.assert_awaited_with("❌")
     assert "bad OCR" in message.reply.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_includes_a_markdown_traceback_by_default(
+    handler, message
+):
+    handler.receipt_processor.process_image_bytes.side_effect = RuntimeError(
+        "tesseract missing"
+    )
+
+    await handler.handle(message)
+
+    reply = message.reply.await_args.args[0]
+    assert reply.startswith(
+        "An unexpected error occurred while processing the receipt.\n"
+        "**Traceback**\n```py\nTraceback (most recent call last):"
+    )
+    assert "RuntimeError: tesseract missing" in reply
+    assert reply.endswith("\n```")
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_hides_the_traceback_when_disabled(message):
+    handler = ReceiptChannelHandler(
+        "receipts",
+        MagicMock(),
+        MagicMock(spec=ReceiptProcessor),
+        show_error_tracebacks=False,
+    )
+    handler.receipt_processor.process_image_bytes.side_effect = RuntimeError(
+        "tesseract missing"
+    )
+
+    await handler.handle(message)
+
+    message.reply.assert_awaited_once_with(
+        "An unexpected error occurred while processing the receipt. "
+        "The error has been logged."
+    )

--- a/tests/unit_tests/test_receipt_parser.py
+++ b/tests/unit_tests/test_receipt_parser.py
@@ -332,6 +332,45 @@ Data: 15.03.2026 Czas: 10:30
         receipt = parser.parse(text, source="pdf")
         assert receipt.date == date(2026, 3, 15)
 
+    def test_kaufland_app_screenshot_ocr_format(self, parser):
+        text = """\
+20:22 © 3 ul GM
+Podsumowanie zakupów
+Kaufland Wrocław-Szczepin
+ul. Długa 37/47
+Wrocław
+Cena w
+Torba zakupowa 0,89
+Kubuś100%BanJabBrzos 4,49
+butelkaPET 0,50
+PiątnicaSkyrNat150g 3,19
+CedrobKurczakGotowany 4,28
+Krasnystawkefir420g 2,89
+ActiviaDoPicia270g 4,99
+Zupa krem z dyni450G 6,29
+TwójSmakSerek150g 4,99
+Smaki Victorii 250ml 4,69
+Banany kg 6,67
+STD Pol Pomidor mięs cze... 5,33
+Winogrono jasne bezp. 50... 9,99
+Chleb Baltonowski 500g 2,29
+Suma none 61,48
+Podatek % Brutto Netto Podatek
+A 23% 0,89 0,72 0,17
+"""
+
+        receipt = parser.parse(text, source="photo")
+
+        assert receipt.store_name == "Kaufland Wrocław-Szczepin"
+        assert receipt.total == Decimal("61.48")
+        assert receipt.source == "photo"
+        assert len(receipt.items) == 14
+        assert receipt.items[0].name == "Torba zakupowa"
+        assert receipt.items[0].total_price == Decimal("0.89")
+        assert receipt.items[-1].name == "Chleb Baltonowski 500g"
+        assert receipt.items[-1].total_price == Decimal("2.29")
+        assert ReceiptProcessor.validate_receipt(receipt) == (True, Decimal("0.00"))
+
 
 class TestWeightedItems:
     """Test parsing of weighted/measured items."""


### PR DESCRIPTION
## What changed

- install Tesseract and Polish language data in the final production container
- share the Discord-safe traceback formatter and apply `DISCORD_SHOW_ERROR_TRACEBACKS` to receipt failures
- parse Kaufland app screenshot OCR where product names and prices appear on the same line
- add regression coverage for receipt traceback configuration and the screenshot format

## Root cause

The multi-stage Dockerfile installed Tesseract only in builder and development stages. The published production stage retained `pytesseract` but discarded the `tesseract` executable and Polish language data, so every image receipt raised `TesseractNotFoundError`.

Receipt handling also caught unexpected exceptions locally and always sent a generic reply. That bypassed the traceback formatter added for notification and schedule failures. Finally, the digital receipt parser supported PDF extraction's alternating price/name lines but not the same-line name/price layout produced by OCR on the Kaufland app screenshot.

## Impact

Image OCR can run in the published production image, unexpected receipt failures honor the existing traceback setting, and the supplied Kaufland screenshot parses as 14 items totaling 61.48 PLN.

The supplied paper-receipt photo no longer crashes, but its OCR text still fails item-total validation. The bot therefore remains fail-closed and will warn without creating a transaction for that photo.

## Validation

- `venv/bin/pytest tests/unit_tests -q --no-cov` — 224 passed
- `venv/bin/pytest tests/integration_tests/test_ocr_pipeline.py -q --no-cov` — 4 passed
- `venv/bin/ruff check .`
- `venv/bin/mypy actual_discord_bot`
- production Docker image build
- runtime check for `tesseract` and Polish language data
- full OCR/parser run against both supplied images