### PR TITLE
Make catch-up channel-aware

### DIFF
--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -7,6 +7,14 @@ applyTo: '**/*.py'
 
 A Discord bot that creates Actual Budget transactions from bank push notifications forwarded via Android's Automate app, and from receipt photos/PDFs posted to a dedicated channel.
 
+## Repository-wide agent guidance
+
+Read the repository-root [`AGENTS.md`](../../AGENTS.md) before investigating a
+production issue. It is the authoritative Lenovo log-access, privacy, and deployment
+boundary guide. In particular, this repository may inspect production read-only but
+must not deploy or mutate the Lenovo; deployment is performed from
+`/root/my-nixos-configuration`.
+
 ## Tech Stack
 
 - **Python 3.13** with **Poetry** for dependency management

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,115 @@
+# Production debugging on the Lenovo
+
+## Scope and deployment boundary
+
+This repository owns the Discord bot source, tests, container image, and releases.
+It does **not** own production activation. The Lenovo ThinkCentre M710q is declared
+and deployed from `/root/my-nixos-configuration` using its transactional
+`nix run .#deploy` workflow.
+
+For project structure, coding conventions, and local test commands, also read
+[`.github/instructions/general.instructions.md`](.github/instructions/general.instructions.md).
+Those instructions defer to this file for production log access, privacy, and the
+deployment boundary.
+
+When diagnosing a production issue, agents may use the read-only SSH commands below
+to inspect the deployed bot. Do not run `docker compose up`, `docker restart`,
+`systemctl restart`, `nixos-rebuild`, `nix run .#deploy`, or any other command that
+changes the Lenovo's state from this repository. Prepare and test a source fix here;
+release it; then hand the deployment request to the NixOS configuration repository.
+
+## Production access
+
+The production host and bot container are:
+
+```text
+SSH host:       admin@think-centre.home
+SSH identity:   /root/.ssh/mini_pc_provision_ed25519
+systemd unit:   mini-pc-discord-bot.service
+container:      mini-pc-actual-actual-discord-bot-1
+```
+
+Use key-only, non-interactive SSH with a connection timeout. The `admin` account has
+the narrowly required passwordless sudo access for operational inspection:
+
+```bash
+ssh -i /root/.ssh/mini_pc_provision_ed25519 \
+  -o BatchMode=yes -o ConnectTimeout=15 \
+  admin@think-centre.home \
+  'sudo systemctl status --no-pager mini-pc-discord-bot'
+```
+
+Never print, copy, modify, or commit the private identity, runtime environment files,
+Docker environment variables, Discord tokens, Actual credentials, backups, or user
+financial data. Receipt OCR, bank notifications, and exception context in logs can
+contain sensitive data: treat command output as private diagnostic material and
+redact it before including it in an issue, PR, or chat response.
+
+## Read-only investigation workflow
+
+Start with current state and the deployed immutable image:
+
+```bash
+ssh -i /root/.ssh/mini_pc_provision_ed25519 \
+  -o BatchMode=yes -o ConnectTimeout=15 \
+  admin@think-centre.home \
+  'sudo docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"'
+```
+
+Inspect the service-launcher events; this unit starts Compose, so it is useful for
+restart, image-load, and health-gate failures but does not contain the bot's normal
+application output:
+
+```bash
+ssh -i /root/.ssh/mini_pc_provision_ed25519 \
+  -o BatchMode=yes -o ConnectTimeout=15 \
+  admin@think-centre.home \
+  'sudo journalctl -u mini-pc-discord-bot --since "6 hours ago" --no-pager -n 200'
+```
+
+For bot exceptions and receipt-processing diagnostics, inspect the container logs.
+Use a bounded time range and tail; do not follow the stream indefinitely unless the
+user explicitly asks for live monitoring:
+
+```bash
+ssh -i /root/.ssh/mini_pc_provision_ed25519 \
+  -o BatchMode=yes -o ConnectTimeout=15 \
+  admin@think-centre.home \
+  'sudo docker logs --timestamps --since 6h --tail 300 mini-pc-actual-actual-discord-bot-1'
+```
+
+For an initial low-volume error scan, use the same command with a narrow pattern,
+then retrieve only the necessary surrounding lines after identifying a timestamp:
+
+```bash
+ssh -i /root/.ssh/mini_pc_provision_ed25519 \
+  -o BatchMode=yes -o ConnectTimeout=15 \
+  admin@think-centre.home \
+  'sudo docker logs --timestamps --since 24h --tail 1000 mini-pc-actual-actual-discord-bot-1 2>&1 | grep -Ei "traceback|exception|error|failed" || true'
+```
+
+Confirm container health without revealing configuration values:
+
+```bash
+ssh -i /root/.ssh/mini_pc_provision_ed25519 \
+  -o BatchMode=yes -o ConnectTimeout=15 \
+  admin@think-centre.home \
+  'sudo docker inspect --format "{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{end}}" mini-pc-actual-actual-discord-bot-1'
+```
+
+If the expected container is absent, rerun `docker ps --format ...` and use the
+reported name. Do not guess a Compose project name or alter production to make the
+name match this document.
+
+## Reporting and fixing
+
+Report the deployed image reference, relevant timestamps in Europe/Warsaw, container
+health, the exception type and redacted stack frames, and whether the issue reproduces
+locally. Do not report raw receipt text, transaction amounts, account names, Discord
+message IDs, or secrets.
+
+For a code change, add a focused regression test and run the repository's normal
+formatting, lint, and test commands. A release alone does not change the Lenovo. State
+clearly in the PR or handoff that deployment must be requested in
+`/root/my-nixos-configuration`, where the image digest is pinned and activation is
+transactional with health-check rollback.

--- a/actual_discord_bot/bot.py
+++ b/actual_discord_bot/bot.py
@@ -38,6 +38,9 @@ LOGGER = logging.getLogger(__name__)
 CATCH_UP_TIME_DELTA_ERROR = (
     "Error: Invalid time delta. Use X hour(s), X day(s), or X month(s)."
 )
+CATCH_UP_CHANNEL_ERROR = (
+    "Error: This command can only be used in the bank notification channel."
+)
 BULK_DELETE_SAFE_AGE = timedelta(days=13, hours=23)
 MAX_BULK_DELETE_MESSAGES = 100
 
@@ -140,7 +143,11 @@ class ActualDiscordBot(commands.Bot):
                 return
 
     async def _catch_up(self, ctx: commands.Context, time_delta: str = "") -> None:
-        """Retry notification messages that have not yet been imported."""
+        """Retry notification messages in the invoking notification channel."""
+        if not self.notification_handler.matches(ctx.channel):
+            await ctx.send(CATCH_UP_CHANNEL_ERROR)
+            return
+
         try:
             after = parse_catch_up_after(time_delta, discord.utils.utcnow())
         except CatchUpTimeDeltaError:

--- a/actual_discord_bot/bot.py
+++ b/actual_discord_bot/bot.py
@@ -39,7 +39,7 @@ CATCH_UP_TIME_DELTA_ERROR = (
     "Error: Invalid time delta. Use X hour(s), X day(s), or X month(s)."
 )
 CATCH_UP_CHANNEL_ERROR = (
-    "Error: This command can only be used in the bank notification channel."
+    "Error: This command can only be used in a configured watched channel."
 )
 BULK_DELETE_SAFE_AGE = timedelta(days=13, hours=23)
 MAX_BULK_DELETE_MESSAGES = 100
@@ -143,8 +143,11 @@ class ActualDiscordBot(commands.Bot):
                 return
 
     async def _catch_up(self, ctx: commands.Context, time_delta: str = "") -> None:
-        """Retry notification messages in the invoking notification channel."""
-        if not self.notification_handler.matches(ctx.channel):
+        """Reprocess eligible history in the invoking watched channel."""
+        handler = next(
+            (handler for handler in self.handlers if handler.matches(ctx.channel)), None
+        )
+        if handler is None:
             await ctx.send(CATCH_UP_CHANNEL_ERROR)
             return
 
@@ -155,9 +158,9 @@ class ActualDiscordBot(commands.Bot):
             return
 
         if after is None:
-            await self.notification_handler.catch_up(ctx)
+            await handler.catch_up(ctx)
             return
-        await self.notification_handler.catch_up(ctx, after=after)
+        await handler.catch_up(ctx, after=after)
 
     async def _help(self, ctx: commands.Context) -> None:
         """Show the guide or guides for the current channel."""

--- a/actual_discord_bot/channel_handlers/bank_imports.py
+++ b/actual_discord_bot/channel_handlers/bank_imports.py
@@ -42,6 +42,7 @@ I will select an unambiguous open Actual account automatically, or ask the uploa
 
 **Commands**
 `!help` — show this guide
+`!catch_up [X hour(s)|X day(s)|X month(s)]` — reprocess bank-statement messages in this channel
 `!clear_channel` — permanently delete all deletable messages in this watched channel. Requires your Manage Messages permission."""
 
 

--- a/actual_discord_bot/channel_handlers/base.py
+++ b/actual_discord_bot/channel_handlers/base.py
@@ -4,8 +4,10 @@ import logging
 import traceback
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from datetime import datetime
 
 import discord
+from discord.ext import commands
 
 LOGGER = logging.getLogger(__name__)
 SUCCESS_REACTION = "✅"
@@ -72,6 +74,29 @@ class BaseChannelHandler(ABC):
             if message.author == bot_user and message.content == self.help_message:
                 return True
         return False
+
+    async def catch_up(
+        self, ctx: commands.Context, *, after: datetime | None = None
+    ) -> None:
+        """Reprocess eligible, non-bot messages from this handler's channel history."""
+        if self.channel is None:
+            await ctx.send(f"Error: Channel '{self.channel_name}' not found.")
+            return
+
+        processed_count = 0
+        async with ctx.typing():
+            history = (
+                self.channel.history(limit=None, after=after)
+                if after is not None
+                else self.channel.history(limit=None)
+            )
+            async for message in history:
+                if message.author == ctx.bot.user or not self.accepts(message):
+                    continue
+                await self.handle(message)
+                processed_count += 1
+
+        await ctx.send(f"Catch-up complete. Processed {processed_count} messages.")
 
     @abstractmethod
     def accepts(self, message: discord.Message) -> bool:

--- a/actual_discord_bot/channel_handlers/notifications.py
+++ b/actual_discord_bot/channel_handlers/notifications.py
@@ -40,7 +40,7 @@ Timestamp: <timestamp>
 ```
 I react with ✅ and reply with a summary when a transaction is created. If a notification cannot be read or imported, I react with ❌ and reply with the reason. Unexpected import errors are logged for troubleshooting.
 
-`!catch_up` skips my own messages and messages marked with my ✅ or ❌. Add a lookback such as `!catch_up 2 days` to process only recent messages. To request a retry, add any reaction to the message; I will try it again and remove that reaction afterwards, whether the retry succeeds or fails.
+`!catch_up` reprocesses messages in this channel, skipping my own messages and those marked with my ✅ or ❌. Add a lookback such as `!catch_up 2 days` to process only recent messages. To request a retry, add any reaction to the message; I will try it again and remove that reaction afterwards, whether the retry succeeds or fails.
 
 **How notifications reach this channel**
 An administrator can create a Discord webhook for this channel in **Edit Channel → Integrations → Webhooks**. Its webhook URL is the special link that can post messages here—keep it private. On Android, an Automate flow can listen only for notifications from your bank app and send an HTTP POST to that URL, using `application/json` and the format above in the JSON `content` field. Never put your Discord bot token or Actual password in the flow or channel.

--- a/actual_discord_bot/channel_handlers/notifications.py
+++ b/actual_discord_bot/channel_handlers/notifications.py
@@ -40,7 +40,7 @@ Timestamp: <timestamp>
 ```
 I react with ✅ and reply with a summary when a transaction is created. If a notification cannot be read or imported, I react with ❌ and reply with the reason. Unexpected import errors are logged for troubleshooting.
 
-`!catch_up` skips messages marked with my ✅ or ❌. Add a lookback such as `!catch_up 2 days` to process only recent messages. To request a retry, add any reaction to the message; I will try it again and remove that reaction afterwards, whether the retry succeeds or fails.
+`!catch_up` skips my own messages and messages marked with my ✅ or ❌. Add a lookback such as `!catch_up 2 days` to process only recent messages. To request a retry, add any reaction to the message; I will try it again and remove that reaction afterwards, whether the retry succeeds or fails.
 
 **How notifications reach this channel**
 An administrator can create a Discord webhook for this channel in **Edit Channel → Integrations → Webhooks**. Its webhook URL is the special link that can post messages here—keep it private. On Android, an Automate flow can listen only for notifications from your bank app and send an HTTP POST to that URL, using `application/json` and the format above in the JSON `content` field. Never put your Discord bot token or Actual password in the flow or channel.
@@ -286,6 +286,8 @@ class NotificationChannelHandler(BaseChannelHandler):
                 else self.channel.history(limit=None)
             )
             async for message in history:
+                if message.author == ctx.bot.user:
+                    continue
                 if not self._should_retry(message):
                     continue
                 try:

--- a/actual_discord_bot/channel_handlers/receipts.py
+++ b/actual_discord_bot/channel_handlers/receipts.py
@@ -35,6 +35,7 @@ I react with ✅ and reply with a summary when a transaction is created. ⚠️ 
 
 **Commands**
 `!help` — show this receipt guide
+`!catch_up [X hour(s)|X day(s)|X month(s)]` — reprocess receipt messages in this channel
 `!clear_channel` — permanently delete all deletable messages in this watched channel. Requires your Manage Messages permission.
 
 Receipts may contain sensitive information, so only post them in a private channel that is visible to people you trust."""

--- a/tests/unit_tests/test_bot.py
+++ b/tests/unit_tests/test_bot.py
@@ -501,7 +501,7 @@ async def test_catch_up_rejects_invalid_lookback_without_processing(bot):
 
 
 @pytest.mark.asyncio
-async def test_catch_up_rejects_a_non_notification_channel(bot):
+async def test_catch_up_rejects_an_unwatched_channel(bot):
     ctx = AsyncMock()
     bot.notification_handler.channel = _channel(1, "bank-notifications")
     ctx.channel = _channel(2, "paragony")
@@ -515,6 +515,44 @@ async def test_catch_up_rejects_a_non_notification_channel(bot):
 
     ctx.send.assert_awaited_once_with(CATCH_UP_CHANNEL_ERROR)
     catch_up.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_catch_up_delegates_to_receipt_handler_in_its_channel(bot):
+    receipt_handler = ReceiptChannelHandler("paragony", MagicMock(), MagicMock())
+    bot = ActualDiscordBot(bot.notification_handler, receipt_handler)
+    ctx = AsyncMock()
+    receipt_channel = _channel(2, "paragony")
+    receipt_handler.channel = receipt_channel
+    ctx.channel = receipt_channel
+
+    with patch.object(receipt_handler, "catch_up", new=AsyncMock()) as catch_up:
+        command = bot.get_command("catch_up")
+        assert command is not None
+        await command.callback(ctx)
+
+    catch_up.assert_awaited_once_with(ctx)
+
+
+@pytest.mark.asyncio
+async def test_catch_up_delegates_to_bank_import_handler_in_its_channel(bot):
+    bank_import_handler = BankImportChannelHandler(
+        "bank-imports", MagicMock(), ZoneInfo("Europe/Warsaw")
+    )
+    bot = ActualDiscordBot(
+        bot.notification_handler, bank_import_handler=bank_import_handler
+    )
+    ctx = AsyncMock()
+    bank_import_channel = _channel(2, "bank-imports")
+    bank_import_handler.channel = bank_import_channel
+    ctx.channel = bank_import_channel
+
+    with patch.object(bank_import_handler, "catch_up", new=AsyncMock()) as catch_up:
+        command = bot.get_command("catch_up")
+        assert command is not None
+        await command.callback(ctx)
+
+    catch_up.assert_awaited_once_with(ctx)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_bot.py
+++ b/tests/unit_tests/test_bot.py
@@ -11,6 +11,7 @@ import actual_discord_bot.bot as bot_module
 from actual_discord_bot import ActualDiscordBot
 from actual_discord_bot.bot import (
     BULK_DELETE_SAFE_AGE,
+    CATCH_UP_CHANNEL_ERROR,
     CATCH_UP_TIME_DELTA_ERROR,
     CatchUpTimeDeltaError,
     ClearChannelResult,
@@ -450,6 +451,9 @@ async def test_help_sends_both_shared_channel_guides():
 @pytest.mark.asyncio
 async def test_catch_up_delegates_to_notification_handler(bot):
     ctx = AsyncMock()
+    notification_channel = _channel(1, "bank-notifications")
+    bot.notification_handler.channel = notification_channel
+    ctx.channel = notification_channel
     with patch.object(
         bot.notification_handler, "catch_up", new=AsyncMock()
     ) as catch_up:
@@ -462,6 +466,9 @@ async def test_catch_up_delegates_to_notification_handler(bot):
 @pytest.mark.asyncio
 async def test_catch_up_passes_valid_lookback_to_notification_handler(bot):
     ctx = AsyncMock()
+    notification_channel = _channel(1, "bank-notifications")
+    bot.notification_handler.channel = notification_channel
+    ctx.channel = notification_channel
     now = datetime(2026, 8, 2, 15, 30, tzinfo=UTC)
     with (
         patch.object(bot_module.discord.utils, "utcnow", return_value=now),
@@ -479,6 +486,9 @@ async def test_catch_up_passes_valid_lookback_to_notification_handler(bot):
 @pytest.mark.asyncio
 async def test_catch_up_rejects_invalid_lookback_without_processing(bot):
     ctx = AsyncMock()
+    notification_channel = _channel(1, "bank-notifications")
+    bot.notification_handler.channel = notification_channel
+    ctx.channel = notification_channel
     with patch.object(
         bot.notification_handler, "catch_up", new=AsyncMock()
     ) as catch_up:
@@ -487,6 +497,23 @@ async def test_catch_up_rejects_invalid_lookback_without_processing(bot):
         await command.callback(ctx, time_delta="a few days")
 
     ctx.send.assert_awaited_once_with(CATCH_UP_TIME_DELTA_ERROR)
+    catch_up.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_catch_up_rejects_a_non_notification_channel(bot):
+    ctx = AsyncMock()
+    bot.notification_handler.channel = _channel(1, "bank-notifications")
+    ctx.channel = _channel(2, "paragony")
+
+    with patch.object(
+        bot.notification_handler, "catch_up", new=AsyncMock()
+    ) as catch_up:
+        command = bot.get_command("catch_up")
+        assert command is not None
+        await command.callback(ctx)
+
+    ctx.send.assert_awaited_once_with(CATCH_UP_CHANNEL_ERROR)
     catch_up.assert_not_awaited()
 
 

--- a/tests/unit_tests/test_channel_handler_base.py
+++ b/tests/unit_tests/test_channel_handler_base.py
@@ -40,3 +40,25 @@ async def test_guide_is_sent_once_and_skips_recent_bot_guide():
     await handler.announce_help(bot_user)
     await handler.announce_help(bot_user)
     channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_catch_up_reprocesses_accepted_non_bot_messages():
+    handler = SampleHandler()
+    channel = AsyncMock(spec=discord.TextChannel)
+    handler.channel = channel
+    bot_user = MagicMock()
+    bot_message = MagicMock(author=bot_user)
+    user_message = MagicMock(author=MagicMock())
+    channel.history.return_value.__aiter__.return_value = [bot_message, user_message]
+    handler.handle = AsyncMock()
+    ctx = MagicMock()
+    ctx.bot.user = bot_user
+    ctx.send = AsyncMock()
+    ctx.typing.return_value.__aenter__ = AsyncMock(return_value=None)
+    ctx.typing.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    await handler.catch_up(ctx)
+
+    handler.handle.assert_awaited_once_with(user_message)
+    ctx.send.assert_awaited_once_with("Catch-up complete. Processed 1 messages.")

--- a/tests/unit_tests/test_notification_channel_handler.py
+++ b/tests/unit_tests/test_notification_channel_handler.py
@@ -147,6 +147,31 @@ async def test_catch_up_skips_bot_status_reactions_and_retries_unmarked_messages
 
 
 @pytest.mark.asyncio
+async def test_catch_up_skips_messages_authored_by_the_bot(handler):
+    channel = AsyncMock(spec=discord.TextChannel)
+    handler.channel = channel
+    bot_user = MagicMock()
+    bot_message = AsyncMock(spec=discord.Message)
+    bot_message.author = bot_user
+    bot_message.reactions = []
+    notification = AsyncMock(spec=discord.Message)
+    notification.author = MagicMock()
+    notification.reactions = []
+    channel.history.return_value.__aiter__.return_value = [bot_message, notification]
+    ctx = MagicMock()
+    ctx.bot.user = bot_user
+    ctx.send = AsyncMock()
+    ctx.typing.return_value.__aenter__ = AsyncMock(return_value=None)
+    ctx.typing.return_value.__aexit__ = AsyncMock(return_value=None)
+    handler.handle = AsyncMock()
+
+    await handler.catch_up(ctx)
+
+    handler.handle.assert_awaited_once_with(notification)
+    ctx.send.assert_awaited_once_with("Catch-up complete. Processed 1 messages.")
+
+
+@pytest.mark.asyncio
 async def test_catch_up_retries_user_marked_messages_and_removes_the_marker(handler):
     channel = AsyncMock(spec=discord.TextChannel)
     handler.channel = channel


### PR DESCRIPTION
## Summary

- dispatch `!catch_up` to the handler for the channel where it was invoked
- support replaying receipt and bank-statement messages as well as notification messages
- skip bot-authored history messages for every catch-up workflow
- retain notification-specific status/retry behavior

## Root cause

The command always delegated to the notification handler, so an invocation in another tracked channel processed bank-notification history instead of that channel's messages.

## Validation

- `pytest tests/unit_tests/` (229 passed)
- `ruff check actual_discord_bot tests` (passed)
- `ruff format --check actual_discord_bot tests` remains non-clean because eleven pre-existing files are not formatter-compliant; no unrelated formatting was included.

## Deployment

Merging or publishing this source change does not activate it on the Lenovo. Request deployment from `/root/my-nixos-configuration`, which pins the image digest and performs transactional activation with health-check rollback.