### PR TITLE
Add Pekao BLIK notification parsing

### DIFF
--- a/actual_discord_bot/bank_notifications/pekao_notification.py
+++ b/actual_discord_bot/bank_notifications/pekao_notification.py
@@ -37,6 +37,13 @@ class PekaoNotification(BaseNotification):
         ),
         NotificationTemplate(
             re.compile(
+                r"Zapłacono BLIK-iem na kwotę (?P<amount>.+) PLN z konta .+ "
+                r"w (?P<payee>.+)\. Bank Pekao S\.A\.",
+            ),
+            TransactionType.PAYMENT,
+        ),
+        NotificationTemplate(
+            re.compile(
                 r"\s*Wykonano doładowanie telefonu .+ na kwotę (?P<amount>.+) PLN z konta.+, operator: (?P<payee>.+)\. Bank Pekao S\.A\.",
             ),
             TransactionType.PAYMENT,

--- a/tests/unit_tests/test_bank_notification.py
+++ b/tests/unit_tests/test_bank_notification.py
@@ -43,6 +43,16 @@ Bank: Pekao""",
                 bank="Pekao",
             ),
         ),
+        (
+            """Title: Wykonano operację BLIK
+Text: Zapłacono BLIK-iem na kwotę 266,33 PLN z konta *0852 w PAYPRO S.A.. Bank Pekao S.A.
+Bank: Pekao""",
+            PekaoNotification(
+                title="Wykonano operację BLIK",
+                text="Zapłacono BLIK-iem na kwotę 266,33 PLN z konta *0852 w PAYPRO S.A.. Bank Pekao S.A.",
+                bank="Pekao",
+            ),
+        ),
     ],
 )
 def test_from_message(message: str, expected_notification: PekaoNotification):
@@ -115,6 +125,19 @@ def test_from_message(message: str, expected_notification: PekaoNotification):
                 account="Pekao",
                 amount=-Decimal("30.00"),
                 imported_payee="ATT",
+            ),
+        ),
+        (
+            PekaoNotification(
+                title="Wykonano operację BLIK",
+                text="Zapłacono BLIK-iem na kwotę 266,33 PLN z konta *0852 w PAYPRO S.A.. Bank Pekao S.A.",
+                bank="Pekao",
+            ),
+            ActualTransactionData(
+                date=date(2024, 9, 20),
+                account="Pekao",
+                amount=-Decimal("266.33"),
+                imported_payee="PAYPRO S.A.",
             ),
         ),
     ],

--- a/tests/unit_tests/test_bank_notification.py
+++ b/tests/unit_tests/test_bank_notification.py
@@ -45,11 +45,11 @@ Bank: Pekao""",
         ),
         (
             """Title: Wykonano operację BLIK
-Text: Zapłacono BLIK-iem na kwotę 266,33 PLN z konta *0852 w PAYPRO S.A.. Bank Pekao S.A.
+Text: Zapłacono BLIK-iem na kwotę 266,33 PLN z konta [redacted] w PAYPRO S.A.. Bank Pekao S.A.
 Bank: Pekao""",
             PekaoNotification(
                 title="Wykonano operację BLIK",
-                text="Zapłacono BLIK-iem na kwotę 266,33 PLN z konta *0852 w PAYPRO S.A.. Bank Pekao S.A.",
+                text="Zapłacono BLIK-iem na kwotę 266,33 PLN z konta [redacted] w PAYPRO S.A.. Bank Pekao S.A.",
                 bank="Pekao",
             ),
         ),
@@ -130,7 +130,7 @@ def test_from_message(message: str, expected_notification: PekaoNotification):
         (
             PekaoNotification(
                 title="Wykonano operację BLIK",
-                text="Zapłacono BLIK-iem na kwotę 266,33 PLN z konta *0852 w PAYPRO S.A.. Bank Pekao S.A.",
+                text="Zapłacono BLIK-iem na kwotę 266,33 PLN z konta [redacted] w PAYPRO S.A.. Bank Pekao S.A.",
                 bank="Pekao",
             ),
             ActualTransactionData(


### PR DESCRIPTION
## What changed

Adds a Pekao notification template for BLIK payments such as `Zapłacono BLIK-iem na kwotę …`.

## Why

These payment notifications were not recognized, so they could not be imported into Actual.

## Impact

BLIK payments are imported as outgoing transactions with the merchant as the payee and the Polish-formatted amount parsed correctly.

## Validation

- `ruff format --check actual_discord_bot/bank_notifications/pekao_notification.py tests/unit_tests/test_bank_notification.py`
- `ruff check actual_discord_bot/bank_notifications/pekao_notification.py tests/unit_tests/test_bank_notification.py`
- `pytest tests/unit_tests/` (231 passed)