### PR TITLE
Fix schedule reply reaction lookup

### DIFF
--- a/actual_discord_bot/channel_handlers/notifications.py
+++ b/actual_discord_bot/channel_handlers/notifications.py
@@ -236,21 +236,18 @@ class NotificationChannelHandler(BaseChannelHandler):
             )
             return None
 
-        resolved = reference.resolved
-        if resolved is not None and not isinstance(
-            resolved, discord.DeletedReferencedMessage
-        ):
-            source_message = resolved
-        else:
-            try:
-                source_message = await self.channel.fetch_message(reference.message_id)  # type: ignore[union-attr]
-            except (discord.Forbidden, discord.HTTPException, discord.NotFound):
-                LOGGER.warning(
-                    "Could not fetch schedule source notification %s",
-                    reference.message_id,
-                )
-                await ctx.reply("Error: The replied-to notification is unavailable.")
-                return None
+        # The gateway's embedded referenced message can be partial and omit its
+        # reactions. Fetch the source so the success-reaction check below uses
+        # the current, complete message rather than a stale reply payload.
+        try:
+            source_message = await self.channel.fetch_message(reference.message_id)  # type: ignore[union-attr]
+        except (discord.Forbidden, discord.HTTPException, discord.NotFound):
+            LOGGER.warning(
+                "Could not fetch schedule source notification %s",
+                reference.message_id,
+            )
+            await ctx.reply("Error: The replied-to notification is unavailable.")
+            return None
         if not _same_channel(source_message.channel, self.channel):
             await ctx.reply(
                 "Error: Reply to a notification in this bank notification channel."

--- a/tests/unit_tests/test_schedules.py
+++ b/tests/unit_tests/test_schedules.py
@@ -149,8 +149,11 @@ def _message(channel):
 @pytest.mark.asyncio
 async def test_make_schedule_uses_reply_target_and_reports_created_schedule():
     channel = MagicMock(id=10)
+    resolved_source = _message(channel)
+    resolved_source.reactions = []
     source = _message(channel)
-    reference = MagicMock(message_id=101, channel_id=10, resolved=source)
+    channel.fetch_message = AsyncMock(return_value=source)
+    reference = MagicMock(message_id=101, channel_id=10, resolved=resolved_source)
     ctx = MagicMock()
     ctx.channel = channel
     ctx.message.reference = reference
@@ -174,6 +177,7 @@ async def test_make_schedule_uses_reply_target_and_reports_created_schedule():
             handler_ctx := ctx, ScheduleRecurrence(2, RecurrenceFrequency.MONTHLY)
         )
 
+    channel.fetch_message.assert_awaited_once_with(101)
     connector.create_schedule.assert_called_once_with(
         ActualScheduleData(
             start=date(2024, 9, 23),
@@ -256,6 +260,7 @@ async def test_make_schedule_rejects_invalid_reply_states(
 async def test_make_schedule_translates_missing_actual_sources():
     channel = MagicMock(id=10)
     source = _message(channel)
+    channel.fetch_message = AsyncMock(return_value=source)
     ctx = MagicMock(channel=channel, reply=AsyncMock())
     ctx.message.reference = MagicMock(message_id=101, channel_id=10, resolved=source)
     connector = MagicMock()
@@ -280,6 +285,7 @@ async def test_make_schedule_translates_missing_actual_sources():
 async def test_make_schedule_includes_a_markdown_traceback_for_unexpected_errors():
     channel = MagicMock(id=10)
     source = _message(channel)
+    channel.fetch_message = AsyncMock(return_value=source)
     ctx = MagicMock(channel=channel, reply=AsyncMock())
     ctx.message.reference = MagicMock(message_id=101, channel_id=10, resolved=source)
     connector = MagicMock()


### PR DESCRIPTION
## Summary

- Fetch the replied-to bank notification before checking for the bot's success reaction.
- Add regression coverage for Discord reply payloads that omit reactions.

## Root cause

Discord can provide a partial resolved reply object without reaction data. The schedule command treated that object as authoritative, so a successfully imported notification could incorrectly appear not to have the bot's ✅ reaction.

## Validation

- `pytest tests/unit_tests/` (231 passed)
- `ruff check .`
- `ruff format --check actual_discord_bot/channel_handlers/notifications.py tests/unit_tests/test_schedules.py`

Repository-wide `ruff format --check .` reports 11 existing unrelated files that would be reformatted; this PR leaves them untouched.

## Deployment

After merge, request image pinning and transactional activation from `/root/my-nixos-configuration`; merging this PR does not deploy the Lenovo bot.