### PR TITLE
Add Revolut notification parsing

### DIFF
--- a/actual_discord_bot/bank_notifications/__init__.py
+++ b/actual_discord_bot/bank_notifications/__init__.py
@@ -1,3 +1,6 @@
 from actual_discord_bot.bank_notifications.pekao_notification import PekaoNotification
+from actual_discord_bot.bank_notifications.revolut_notification import (
+    RevolutNotification,
+)
 
-__all__ = ["PekaoNotification"]
+__all__ = ["PekaoNotification", "RevolutNotification"]

--- a/actual_discord_bot/bank_notifications/base_notification.py
+++ b/actual_discord_bot/bank_notifications/base_notification.py
@@ -31,9 +31,15 @@ class BaseNotification:
 
     _message_regexes: ClassVar[tuple[re.Pattern[str], ...]] = (
         re.compile(
-            r"Title: (?P<title>.+)\nText: (?P<text>.+)\nTimestamp: (?P<timestamp>.+)"
+            r"^Title: (?P<title>[^\n]+)\nText: (?P<text>.+)\nTimestamp: "
+            r"(?P<timestamp>[^\n]+)$",
+            re.DOTALL,
         ),
-        re.compile(r"Title: (?P<title>.+)\nText: (?P<text>.+)\nBank: (?P<bank>.+)"),
+        re.compile(
+            r"^Title: (?P<title>[^\n]+)\nText: (?P<text>.+)\nBank: "
+            r"(?P<bank>[^\n]+)$",
+            re.DOTALL,
+        ),
     )
     _notification_regexes: ClassVar[Sequence[NotificationTemplate]]
 

--- a/actual_discord_bot/bank_notifications/revolut_notification.py
+++ b/actual_discord_bot/bank_notifications/revolut_notification.py
@@ -1,0 +1,23 @@
+import re
+from dataclasses import dataclass
+
+from actual_discord_bot.bank_notifications.base_notification import (
+    BaseNotification,
+    NotificationTemplate,
+)
+from actual_discord_bot.enums import TransactionType
+
+
+@dataclass
+class RevolutNotification(BaseNotification):
+    bank: str = "Revolut"
+
+    _notification_regexes = (
+        NotificationTemplate(
+            re.compile(
+                r"Zapłacono (?P<amount>\d{1,3}(?:[ .]\d{3})*,\d{2}) zł w: "
+                r"(?P<payee>.+?)\."
+            ),
+            TransactionType.PAYMENT,
+        ),
+    )

--- a/actual_discord_bot/channel_handlers/notifications.py
+++ b/actual_discord_bot/channel_handlers/notifications.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import re
 from datetime import UTC, datetime
 from decimal import Decimal
 from enum import StrEnum
@@ -15,7 +16,7 @@ from actual_discord_bot.actual_connector import (
     ActualScheduleData,
     ScheduleCreationStatus,
 )
-from actual_discord_bot.bank_notifications import PekaoNotification
+from actual_discord_bot.bank_notifications import PekaoNotification, RevolutNotification
 from actual_discord_bot.bank_notifications.base_notification import BaseNotification
 from actual_discord_bot.channel_handlers.base import (
     SUCCESS_REACTION,
@@ -29,10 +30,12 @@ from actual_discord_bot.schedules import ScheduleRecurrence
 LOGGER = logging.getLogger(__name__)
 ERROR_REACTION = "❌"
 DEFAULT_NOTIFICATION_TIMEZONE = ZoneInfo("Europe/Warsaw")
+FORWARDED_BANK_REGEX = re.compile(r"^Bank: (?P<bank>[^\n]+)$", re.MULTILINE)
+NOTIFICATION_TYPES = (PekaoNotification, RevolutNotification)
 
 NOTIFICATION_HELP_MESSAGE = """👋 **Hello! I am your Actual Budget notification assistant.**
 
-I watch this channel for bank notifications and turn them into transactions in Actual Budget. Currently I understand Bank Pekao card payments, incoming and outgoing transfers, and phone top-ups forwarded in this format:
+I watch this channel for bank notifications and turn them into transactions in Actual Budget. Currently I understand Bank Pekao card payments, incoming and outgoing transfers, and phone top-ups, plus Revolut card payments, forwarded in this format:
 ```
 Title: <notification title>
 Text: <notification text>
@@ -126,7 +129,9 @@ class NotificationChannelHandler(BaseChannelHandler):
         self, message: discord.Message
     ) -> ActualTransactionData:
         """Apply one source-date policy to imports and schedule creation."""
-        notification = self.notification_type.from_message(message.content)
+        notification = self._notification_type_for_message(
+            message.content
+        ).from_message(message.content)
         created_at = message.created_at
         if created_at.tzinfo is None:
             created_at = created_at.replace(tzinfo=UTC)
@@ -135,6 +140,16 @@ class NotificationChannelHandler(BaseChannelHandler):
             timezone=self.timezone,
             fallback_date=fallback_date,
         )
+
+    def _notification_type_for_message(self, message: str) -> type[BaseNotification]:
+        """Select the bank parser named by the forwarded notification envelope."""
+        if matched := FORWARDED_BANK_REGEX.search(message):
+            bank = matched["bank"].strip().casefold()
+            for notification_type in NOTIFICATION_TYPES:
+                if notification_type.bank.casefold() == bank:
+                    return notification_type
+            raise ParseNotificationError(message)
+        return self.notification_type
 
     async def make_schedule(
         self, ctx: commands.Context, recurrence: ScheduleRecurrence

--- a/tests/unit_tests/test_bank_notification.py
+++ b/tests/unit_tests/test_bank_notification.py
@@ -4,7 +4,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from actual_discord_bot.bank_notifications import PekaoNotification
+from actual_discord_bot.bank_notifications import PekaoNotification, RevolutNotification
 from actual_discord_bot.dataclasses_definitions import ActualTransactionData
 
 
@@ -181,3 +181,23 @@ def test_forwarded_timestamp_uses_the_configured_timezone():
     )
 
     assert transaction.date == date(2024, 9, 23)
+
+
+def test_revolut_payment_ignores_the_balance_in_a_multiline_notification():
+    notification = RevolutNotification.from_message(
+        "Title: Chatgpt 🛍\n"
+        "Text: Zapłacono 34,99 zł w: Chatgpt.\n"
+        "⚠️ Saldo konta „PLN”: 99,08 zł.\n"
+        "Bank: Revolut"
+    )
+
+    transaction = notification.to_transaction(
+        timezone=ZoneInfo("Europe/Warsaw"), fallback_date=date(2026, 8, 10)
+    )
+
+    assert transaction == ActualTransactionData(
+        date=date(2026, 8, 10),
+        account="Revolut",
+        amount=Decimal("-34.99"),
+        imported_payee="Chatgpt",
+    )

--- a/tests/unit_tests/test_notification_channel_handler.py
+++ b/tests/unit_tests/test_notification_channel_handler.py
@@ -64,6 +64,33 @@ async def test_parse_error_is_marked_and_explained(handler):
 
 
 @pytest.mark.asyncio
+async def test_handler_selects_the_revolut_parser_from_the_forwarded_bank():
+    handler = NotificationChannelHandler("bank", MagicMock())
+    handler.actual_connector.config.file = "Household"
+    message = AsyncMock(spec=discord.Message)
+    message.id = 1
+    message.content = (
+        "Title: Chatgpt 🛍\n"
+        "Text: Zapłacono 34,99 zł w: Chatgpt.\n"
+        "⚠️ Saldo konta „PLN”: 99,08 zł.\n"
+        "Bank: Revolut"
+    )
+    message.created_at = datetime(2026, 8, 10, tzinfo=UTC)
+
+    result = await handler.handle(message)
+
+    assert result is MessageHandlingResult.IMPORTED
+    handler.actual_connector.save_transaction.assert_called_once_with(
+        ActualTransactionData(
+            date=date(2026, 8, 10),
+            account="Revolut",
+            amount=Decimal("-34.99"),
+            imported_payee="Chatgpt",
+        )
+    )
+
+
+@pytest.mark.asyncio
 async def test_unexpected_error_includes_a_markdown_traceback_by_default(handler):
     message = AsyncMock(spec=discord.Message)
     message.id = 1
@@ -122,7 +149,9 @@ def test_unexpected_error_escapes_markdown_fences_in_the_traceback():
 
 
 @pytest.mark.asyncio
-async def test_catch_up_skips_bot_status_reactions_and_retries_unmarked_messages(handler):
+async def test_catch_up_skips_bot_status_reactions_and_retries_unmarked_messages(
+    handler,
+):
     channel = AsyncMock(spec=discord.TextChannel)
     handler.channel = channel
     already_imported = AsyncMock(spec=discord.Message)


### PR DESCRIPTION
## Summary
- add a Revolut parser for Polish card-payment notifications
- dispatch notification parsers from the forwarded `Bank` field
- preserve multiline notification text so account balance lines are ignored

## Validation
- `ruff check .`
- `pytest tests/unit_tests/`
- scoped `pre-commit run --files ...`