### PR TITLE
Add notification transfer command

### DIFF
--- a/actual_discord_bot/actual_connector.py
+++ b/actual_discord_bot/actual_connector.py
@@ -13,6 +13,7 @@ from actual.queries import (
 from actual.queries import (
     create_schedule_config,
     create_transaction,
+    create_transfer,
     get_account,
     get_payee,
     get_schedules,
@@ -26,7 +27,10 @@ from actual_discord_bot.bank_imports.models import (
     ImportableActualAccount,
 )
 from actual_discord_bot.config import ActualConfig
-from actual_discord_bot.dataclasses_definitions import ActualTransactionData
+from actual_discord_bot.dataclasses_definitions import (
+    ActualTransactionData,
+    notification_transaction_note,
+)
 from actual_discord_bot.errors import ScheduleSourceNotFound
 from actual_discord_bot.receipts.models import ParsedReceipt
 from actual_discord_bot.receipts.transaction import (
@@ -42,6 +46,17 @@ class ScheduleCreationStatus(StrEnum):
 
     CREATED = "created"
     ALREADY_EXISTS = "already_exists"
+
+
+class TransferCreationStatus(StrEnum):
+    """The outcome of making an imported notification into a transfer."""
+
+    CREATED = "created"
+    ALREADY_EXISTS = "already_exists"
+
+
+class NotificationTransactionNotFoundError(LookupError):
+    """Raised when an imported notification cannot be found in Actual."""
 
 
 @dataclass(frozen=True)
@@ -94,11 +109,70 @@ class ActualConnector:
                 account=transaction_data.account,
                 amount=transaction_data.amount,
                 imported_payee=transaction_data.imported_payee,
+                notes=transaction_data.notes,
             )
             actual.commit()
             actual.session.refresh(transaction)
             actual.session.expunge(transaction)
             return transaction
+
+    def create_transfer_from_notification(
+        self,
+        transaction_data: ActualTransactionData,
+        message_id: int,
+        destination_account_name: str,
+    ) -> TransferCreationStatus:
+        """Replace one imported notification row with Actual's linked transfer rows."""
+        note = notification_transaction_note(message_id)
+        with self._create_actual_manager() as actual:
+            source_account = _find_open_account(actual, transaction_data.account)
+            destination_account = _find_open_account(actual, destination_account_name)
+            if source_account is None or destination_account is None:
+                msg = "The selected Actual account is no longer open"
+                raise ValueError(msg)
+            if source_account.id == destination_account.id:
+                msg = "A transfer requires two different Actual accounts"
+                raise ValueError(msg)
+
+            source_transaction = next(
+                (
+                    transaction
+                    for transaction in get_transactions(
+                        actual.session, account=source_account
+                    )
+                    if transaction.notes == note
+                ),
+                None,
+            )
+            if source_transaction is None:
+                if any(
+                    transaction.notes == note
+                    for transaction in get_transactions(
+                        actual.session, notes=note, transfer=True
+                    )
+                ):
+                    return TransferCreationStatus.ALREADY_EXISTS
+                raise NotificationTransactionNotFoundError
+
+            amount = Decimal(str(transaction_data.amount))
+            if amount == 0:
+                msg = "A zero-value transaction cannot be made into a transfer"
+                raise ValueError(msg)
+            if amount < 0:
+                source, destination = source_account, destination_account
+            else:
+                source, destination = destination_account, source_account
+            create_transfer(
+                actual.session,
+                date=transaction_data.date,
+                source_account=source,
+                dest_account=destination,
+                amount=abs(amount),
+                notes=note,
+            )
+            source_transaction.delete()
+            actual.commit()
+            return TransferCreationStatus.CREATED
 
     def save_receipt_transaction(
         self,

--- a/actual_discord_bot/bot.py
+++ b/actual_discord_bot/bot.py
@@ -94,10 +94,16 @@ class ActualDiscordBot(commands.Bot):
         ) -> None:
             await self._make_schedule(ctx, time_delta)
 
+        async def transfer_command(
+            ctx: commands.Context, *, account_name: str = ""
+        ) -> None:
+            await self.notification_handler.make_transfer(ctx, account_name)
+
         self.add_command(commands.Command(catch_up_command, name="catch_up"))
         self.add_command(commands.Command(clear_channel_command, name="clear_channel"))
         self.add_command(commands.Command(help_command, name="help"))
         self.add_command(commands.Command(make_schedule_command, name="make_schedule"))
+        self.add_command(commands.Command(transfer_command, name="transfer"))
         self.handlers: tuple[BaseChannelHandler, ...] = tuple(
             handler
             for handler in (bank_import_handler, receipt_handler, notification_handler)
@@ -183,7 +189,9 @@ class ActualDiscordBot(commands.Bot):
         if not isinstance(ctx.channel, discord.TextChannel) or not isinstance(
             ctx.author, discord.Member
         ):
-            await ctx.send("Error: This command can only be used in a server text channel.")
+            await ctx.send(
+                "Error: This command can only be used in a server text channel."
+            )
             return
 
         if not ctx.channel.permissions_for(ctx.author).manage_messages:

--- a/actual_discord_bot/channel_handlers/notifications.py
+++ b/actual_discord_bot/channel_handlers/notifications.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import re
+from dataclasses import replace
 from datetime import UTC, datetime
 from decimal import Decimal
 from enum import StrEnum
@@ -14,7 +15,9 @@ from discord.ext import commands
 from actual_discord_bot.actual_connector import (
     ActualConnector,
     ActualScheduleData,
+    NotificationTransactionNotFoundError,
     ScheduleCreationStatus,
+    TransferCreationStatus,
 )
 from actual_discord_bot.bank_notifications import PekaoNotification, RevolutNotification
 from actual_discord_bot.bank_notifications.base_notification import BaseNotification
@@ -23,7 +26,10 @@ from actual_discord_bot.channel_handlers.base import (
     BaseChannelHandler,
     format_unexpected_error,
 )
-from actual_discord_bot.dataclasses_definitions import ActualTransactionData
+from actual_discord_bot.dataclasses_definitions import (
+    ActualTransactionData,
+    notification_transaction_note,
+)
 from actual_discord_bot.errors import ParseNotificationError, ScheduleSourceNotFound
 from actual_discord_bot.schedules import ScheduleRecurrence
 
@@ -32,6 +38,7 @@ ERROR_REACTION = "❌"
 DEFAULT_NOTIFICATION_TIMEZONE = ZoneInfo("Europe/Warsaw")
 FORWARDED_BANK_REGEX = re.compile(r"^Bank: (?P<bank>[^\n]+)$", re.MULTILINE)
 NOTIFICATION_TYPES = (PekaoNotification, RevolutNotification)
+TRANSFER_ACCOUNT_COUNT_FOR_DEFAULT = 2
 
 NOTIFICATION_HELP_MESSAGE = """👋 **Hello! I am your Actual Budget notification assistant.**
 
@@ -52,6 +59,7 @@ An administrator can create a Discord webhook for this channel in **Edit Channel
 `!help` — show this notification guide
 `!catch_up [X hour(s)|X day(s)|X month(s)]` — retry messages in this channel that do not already have my ✅
 `!make_schedule [X day(s)|X week(s)|X month(s)|X year(s)]` — reply to a notification I marked ✅ to create a manual-approval recurring schedule. It defaults to monthly.
+`!transfer [account name]` — reply to a notification I marked ✅ to replace it with an Actual transfer. When there are exactly two open accounts, the destination is selected automatically.
 `!clear_channel` — permanently delete all deletable messages in this watched channel. Requires your Manage Messages permission."""
 
 
@@ -136,9 +144,12 @@ class NotificationChannelHandler(BaseChannelHandler):
         if created_at.tzinfo is None:
             created_at = created_at.replace(tzinfo=UTC)
         fallback_date = created_at.astimezone(self.timezone).date()
-        return notification.to_transaction(
-            timezone=self.timezone,
-            fallback_date=fallback_date,
+        return replace(
+            notification.to_transaction(
+                timezone=self.timezone,
+                fallback_date=fallback_date,
+            ),
+            notes=notification_transaction_note(message.id),
         )
 
     def _notification_type_for_message(self, message: str) -> type[BaseNotification]:
@@ -233,6 +244,76 @@ class NotificationChannelHandler(BaseChannelHandler):
         LOGGER.info("Created schedule for notification message %s", source_message.id)
         await ctx.reply(_format_schedule_summary(schedule_data))
 
+    async def make_transfer(
+        self, ctx: commands.Context, destination_account_name: str = ""
+    ) -> None:
+        """Replace a successfully imported notification with an Actual transfer."""
+        if self.channel is None or not _same_channel(ctx.channel, self.channel):
+            await ctx.reply(
+                "Error: This command can only be used in the bank notification channel."
+            )
+            return
+
+        source_message = await self._referenced_notification(ctx)
+        if source_message is None:
+            return
+        if not _has_success_reaction(source_message):
+            await ctx.reply(
+                "Error: Reply to a notification that I imported successfully (✅)."
+            )
+            return
+
+        try:
+            transaction_data = self._transaction_data_from_message(source_message)
+        except ParseNotificationError:
+            await ctx.reply(
+                "Error: The replied-to message is not a supported bank notification."
+            )
+            return
+
+        destination = await self._transfer_destination(
+            ctx, transaction_data.account, destination_account_name
+        )
+        if destination is None:
+            return
+
+        try:
+            status = await self._save_transfer(
+                transaction_data, source_message.id, destination
+            )
+        except NotificationTransactionNotFoundError:
+            await ctx.reply(
+                "Error: The imported transaction could not be found in Actual. Nothing was changed."
+            )
+            return
+        except ValueError as error:
+            await ctx.reply(f"Error: {error}. Nothing was changed.")
+            return
+        except Exception as error:
+            LOGGER.exception(
+                "Transfer creation failed for notification message %s",
+                source_message.id,
+            )
+            await ctx.reply(
+                format_unexpected_error(
+                    "An unexpected error occurred while creating the transfer.",
+                    error,
+                    show_traceback=self.show_error_tracebacks,
+                )
+            )
+            return
+
+        source, destination_name = _transfer_accounts(transaction_data, destination)
+        if status is TransferCreationStatus.ALREADY_EXISTS:
+            await ctx.reply(
+                f"This notification is already a transfer: **{source}** → **{destination_name}**."
+            )
+            return
+        await ctx.reply(
+            f"Created transfer: **{source}** → **{destination_name}**\n"
+            f"{abs(transaction_data.amount)} PLN · {transaction_data.date.isoformat()}"
+        )
+
     async def _referenced_notification(
         self, ctx: commands.Context
     ) -> discord.Message | None:
@@ -280,6 +361,72 @@ class NotificationChannelHandler(BaseChannelHandler):
         async with self.actual_write_lock:
             return await asyncio.to_thread(
                 self.actual_connector.create_schedule, schedule_data
+            )
+
+    async def _transfer_destination(
+        self,
+        ctx: commands.Context,
+        source_account_name: str,
+        requested_account_name: str,
+    ) -> str | None:
+        accounts = await asyncio.to_thread(self.actual_connector.list_import_accounts)
+        account_names = tuple(account.name for account in accounts)
+        if source_account_name not in account_names:
+            await ctx.reply(
+                "Error: The notification's account is no longer open in Actual. Nothing was changed."
+            )
+            return None
+
+        requested = requested_account_name.strip()
+        if requested:
+            matched = next(
+                (
+                    name
+                    for name in account_names
+                    if name.casefold() == requested.casefold()
+                ),
+                None,
+            )
+            if matched is None:
+                available = ", ".join(f"**{name}**" for name in account_names)
+                await ctx.reply(
+                    f"Error: Account **{requested}** was not found. "
+                    f"Available accounts: {available}."
+                )
+                return None
+            if matched == source_account_name:
+                await ctx.reply(
+                    "Error: Choose an account different from the notification's account."
+                )
+                return None
+            return matched
+
+        if len(account_names) == TRANSFER_ACCOUNT_COUNT_FOR_DEFAULT:
+            return next(name for name in account_names if name != source_account_name)
+        await ctx.reply(
+            "Error: Specify the destination account, for example `!transfer Revolut`."
+        )
+        return None
+
+    async def _save_transfer(
+        self,
+        transaction_data: ActualTransactionData,
+        message_id: int,
+        destination_account_name: str,
+    ) -> TransferCreationStatus:
+        if self.actual_write_lock is None:
+            return await asyncio.to_thread(
+                self.actual_connector.create_transfer_from_notification,
+                transaction_data,
+                message_id,
+                destination_account_name,
+            )
+        async with self.actual_write_lock:
+            return await asyncio.to_thread(
+                self.actual_connector.create_transfer_from_notification,
+                transaction_data,
+                message_id,
+                destination_account_name,
             )
 
     async def catch_up(
@@ -350,6 +497,15 @@ def _format_transaction_summary(
         f"Budget: **{budget}** · Account: **{transaction_data.account}** · "
         "Category: *Uncategorized*"
     )
+
+
+def _transfer_accounts(
+    transaction_data: ActualTransactionData, destination_account_name: str
+) -> tuple[str, str]:
+    """Return the transfer direction based on the notification's signed amount."""
+    if transaction_data.amount < 0:
+        return transaction_data.account, destination_account_name
+    return destination_account_name, transaction_data.account
 
 
 def _same_channel(left: object, right: object) -> bool:

--- a/actual_discord_bot/dataclasses_definitions.py
+++ b/actual_discord_bot/dataclasses_definitions.py
@@ -11,3 +11,8 @@ class ActualTransactionData:
 
     imported_payee: str | None = None
     notes: str = ""
+
+
+def notification_transaction_note(message_id: int) -> str:
+    """Return the stable Actual note used to find a Discord notification later."""
+    return f"Discord notification: {message_id}"

--- a/tests/integration_tests/test_actual_connector.py
+++ b/tests/integration_tests/test_actual_connector.py
@@ -3,16 +3,20 @@ import os
 from datetime import UTC, date, datetime
 from decimal import Decimal
 
-from actual.queries import create_payee, get_schedules, get_transactions
+from actual.queries import create_account, create_payee, get_schedules, get_transactions
 
 from actual_discord_bot.actual_connector import (
     ActualConnector,
     ActualScheduleData,
     ScheduleCreationStatus,
+    TransferCreationStatus,
 )
 from actual_discord_bot.bank_imports.models import BankImportTransaction
 from actual_discord_bot.config import ActualConfig
-from actual_discord_bot.dataclasses_definitions import ActualTransactionData
+from actual_discord_bot.dataclasses_definitions import (
+    ActualTransactionData,
+    notification_transaction_note,
+)
 from actual_discord_bot.schedules import RecurrenceFrequency, ScheduleRecurrence
 
 ACTUAL_TEST_URL = os.environ.get("ACTUAL_TEST_URL", "http://localhost:12013")
@@ -63,6 +67,40 @@ def test_bank_csv_import_is_idempotent_and_creates_a_cleared_transaction(actual)
     assert imported.cleared == 1
     assert imported.notes == "Synthetic bank statement row"
     assert imported.financial_id.startswith("bank2ynab:")
+
+
+def test_notification_transaction_can_be_replaced_with_an_actual_transfer(actual):
+    create_account(actual.session, "TransferDestination")
+    actual.commit()
+    connector = ActualConnector(
+        ActualConfig(url=ACTUAL_TEST_URL, password="test", file="TestBudget"),
+    )
+    source_data = ActualTransactionData(
+        date=date(2026, 8, 2),
+        account="TestAccount",
+        amount=Decimal("-12.34"),
+        imported_payee="Revolut",
+        notes=notification_transaction_note(9),
+    )
+    connector.save_transaction(source_data)
+
+    status = connector.create_transfer_from_notification(
+        source_data, 9, "TransferDestination"
+    )
+
+    assert status is TransferCreationStatus.CREATED
+    source_transfers = get_transactions(
+        actual.session, account="TestAccount", transfer=True
+    )
+    destination_transfers = get_transactions(
+        actual.session, account="TransferDestination", transfer=True
+    )
+    assert len(source_transfers) == 1
+    assert len(destination_transfers) == 1
+    assert source_transfers[0].get_amount() == Decimal("-12.34")
+    assert destination_transfers[0].get_amount() == Decimal("12.34")
+    assert source_transfers[0].transferred_id == destination_transfers[0].id
+    assert destination_transfers[0].transferred_id == source_transfers[0].id
 
 
 def test_schedule_creation_is_manual_and_idempotent(actual):

--- a/tests/unit_tests/test_actual_connector.py
+++ b/tests/unit_tests/test_actual_connector.py
@@ -4,7 +4,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from actual_discord_bot.actual_connector import ActualConnector
+from actual_discord_bot.actual_connector import (
+    ActualConnector,
+    TransferCreationStatus,
+)
 from actual_discord_bot.config import ActualConfig
 from actual_discord_bot.dataclasses_definitions import ActualTransactionData
 from actual_discord_bot.receipts.models import ParsedReceipt, ReceiptItem
@@ -76,6 +79,7 @@ class TestBankNotificationDeduplication:
             account="Pekao",
             amount=Decimal("-23.48"),
             imported_payee="Kaufland",
+            notes="",
         )
 
         with patch(
@@ -103,6 +107,7 @@ class TestBankNotificationDeduplication:
             account="Pekao",
             amount=Decimal("-23.48"),
             imported_payee="Kaufland",
+            notes="",
         )
 
         with patch(
@@ -121,6 +126,7 @@ class TestBankNotificationDeduplication:
             account="Pekao",
             amount=Decimal("-23.48"),
             imported_payee="Kaufland",
+            notes="",
         )
 
     def test_dedup_uses_signed_expense_amount(self, connector, mock_actual_manager):
@@ -209,6 +215,86 @@ class TestBankNotificationDeduplication:
         ):
             connector.save_transaction(transaction_data)
 
+        mock_actual_manager.commit.assert_not_called()
+
+
+class TestNotificationTransfers:
+    def test_replaces_the_imported_transaction_with_a_linked_transfer(
+        self, connector, mock_actual_manager
+    ):
+        source_account = MagicMock(id="pekao")
+        destination_account = MagicMock(id="revolut")
+        imported_transaction = MagicMock(notes="Discord notification: 9")
+        transaction_data = ActualTransactionData(
+            date=date(2026, 8, 2),
+            account="Pekao",
+            amount=Decimal("-12.34"),
+            notes="Discord notification: 9",
+        )
+
+        with (
+            patch(
+                "actual_discord_bot.actual_connector._find_open_account",
+                side_effect=(source_account, destination_account),
+            ),
+            patch(
+                "actual_discord_bot.actual_connector.get_transactions",
+                return_value=(imported_transaction,),
+            ) as get_transactions,
+            patch(
+                "actual_discord_bot.actual_connector.create_transfer"
+            ) as create_transfer,
+        ):
+            status = connector.create_transfer_from_notification(
+                transaction_data, 9, "Revolut"
+            )
+
+        assert status is TransferCreationStatus.CREATED
+        get_transactions.assert_called_once_with(
+            mock_actual_manager.session, account=source_account
+        )
+        create_transfer.assert_called_once_with(
+            mock_actual_manager.session,
+            date=date(2026, 8, 2),
+            source_account=source_account,
+            dest_account=destination_account,
+            amount=Decimal("12.34"),
+            notes="Discord notification: 9",
+        )
+        imported_transaction.delete.assert_called_once_with()
+        mock_actual_manager.commit.assert_called_once_with()
+
+    def test_repeated_command_does_not_create_a_second_transfer(
+        self, connector, mock_actual_manager
+    ):
+        source_account = MagicMock(id="pekao")
+        destination_account = MagicMock(id="revolut")
+        transfer_transaction = MagicMock(notes="Discord notification: 9")
+        transaction_data = ActualTransactionData(
+            date=date(2026, 8, 2),
+            account="Pekao",
+            amount=Decimal("-12.34"),
+        )
+
+        with (
+            patch(
+                "actual_discord_bot.actual_connector._find_open_account",
+                side_effect=(source_account, destination_account),
+            ),
+            patch(
+                "actual_discord_bot.actual_connector.get_transactions",
+                side_effect=((), (transfer_transaction,)),
+            ),
+            patch(
+                "actual_discord_bot.actual_connector.create_transfer"
+            ) as create_transfer,
+        ):
+            status = connector.create_transfer_from_notification(
+                transaction_data, 9, "Revolut"
+            )
+
+        assert status is TransferCreationStatus.ALREADY_EXISTS
+        create_transfer.assert_not_called()
         mock_actual_manager.commit.assert_not_called()
 
 

--- a/tests/unit_tests/test_bot.py
+++ b/tests/unit_tests/test_bot.py
@@ -114,7 +114,7 @@ async def test_setup_hook_starts_hot_reload_when_source_tree_exists(
 
 
 def test_registers_commands_without_self_parameter(bot):
-    for name in ("catch_up", "clear_channel", "help", "make_schedule"):
+    for name in ("catch_up", "clear_channel", "help", "make_schedule", "transfer"):
         command = bot.get_command(name)
         assert command is not None
         assert "self" not in command.params
@@ -125,6 +125,9 @@ def test_registers_commands_without_self_parameter(bot):
     make_schedule = bot.get_command("make_schedule")
     assert make_schedule is not None
     assert "time_delta" in make_schedule.params
+    transfer = bot.get_command("transfer")
+    assert transfer is not None
+    assert "account_name" in transfer.params
 
 
 @pytest.mark.asyncio
@@ -311,7 +314,9 @@ async def test_delete_channel_history_reports_non_deletable_messages_as_incomple
 
 
 @pytest.mark.asyncio
-async def test_delete_channel_history_reports_successful_deletions_before_an_api_error(bot):
+async def test_delete_channel_history_reports_successful_deletions_before_an_api_error(
+    bot,
+):
     now = datetime(2026, 8, 2, 15, 30, tzinfo=UTC)
     channel = _channel(1, "bank-notifications")
     old_message = _message(1, now - BULK_DELETE_SAFE_AGE - timedelta(days=1))
@@ -586,6 +591,19 @@ async def test_make_schedule_rejects_invalid_recurrence_without_delegating(bot):
         "Error: Invalid recurrence. Use X day(s), X week(s), X month(s), or X year(s)."
     )
     make_schedule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_transfer_delegates_the_optional_destination_account(bot):
+    ctx = AsyncMock()
+    with patch.object(
+        bot.notification_handler, "make_transfer", new=AsyncMock()
+    ) as make_transfer:
+        command = bot.get_command("transfer")
+        assert command is not None
+        await command.callback(ctx, account_name="Revolut")
+
+    make_transfer.assert_awaited_once_with(ctx, "Revolut")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_notification_channel_handler.py
+++ b/tests/unit_tests/test_notification_channel_handler.py
@@ -1,10 +1,12 @@
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
 
+from actual_discord_bot.actual_connector import TransferCreationStatus
+from actual_discord_bot.bank_imports.models import ImportableActualAccount
 from actual_discord_bot.channel_handlers.base import format_unexpected_error
 from actual_discord_bot.channel_handlers.notifications import (
     ERROR_REACTION,
@@ -37,7 +39,13 @@ async def test_successful_notification_is_saved_in_a_worker_and_reacted(handler)
     result = await handler.handle(message)
     assert result is MessageHandlingResult.IMPORTED
     handler.actual_connector.save_transaction.assert_called_once_with(
-        notification.to_transaction.return_value
+        ActualTransactionData(
+            date=date(2026, 8, 2),
+            account="Pekao",
+            amount=Decimal("-12.34"),
+            imported_payee="Shop",
+            notes="Discord notification: 1",
+        )
     )
     message.add_reaction.assert_awaited_once_with("✅")
     message.reply.assert_awaited_once_with(
@@ -86,6 +94,7 @@ async def test_handler_selects_the_revolut_parser_from_the_forwarded_bank():
             account="Revolut",
             amount=Decimal("-34.99"),
             imported_payee="Chatgpt",
+            notes="Discord notification: 1",
         )
     )
 
@@ -240,3 +249,88 @@ async def test_catch_up_limits_channel_history_to_the_requested_time(handler):
     await handler.catch_up(ctx, after=after)
 
     channel.history.assert_called_once_with(limit=None, after=after)
+
+
+@pytest.mark.asyncio
+async def test_transfer_automatically_uses_the_other_account_when_there_are_two(
+    handler,
+):
+    channel = AsyncMock(spec=discord.TextChannel)
+    channel.id = 1
+    handler.channel = channel
+    source_message = AsyncMock(spec=discord.Message)
+    source_message.id = 9
+    source_message.channel = channel
+    source_message.reactions = [MagicMock(emoji="✅", me=True)]
+    channel.fetch_message.return_value = source_message
+    transaction_data = ActualTransactionData(
+        date=date(2026, 8, 2),
+        account="Pekao",
+        amount=Decimal("-12.34"),
+        imported_payee="Revolut",
+        notes="Discord notification: 9",
+    )
+    handler.actual_connector.list_import_accounts.return_value = (
+        ImportableActualAccount("Pekao", False),
+        ImportableActualAccount("Revolut", False),
+    )
+    handler.actual_connector.create_transfer_from_notification.return_value = (
+        TransferCreationStatus.CREATED
+    )
+    ctx = AsyncMock()
+    ctx.channel = channel
+    ctx.message.reference = MagicMock(message_id=9, channel_id=1)
+
+    with patch.object(
+        handler, "_transaction_data_from_message", return_value=transaction_data
+    ):
+        await handler.make_transfer(ctx)
+
+    handler.actual_connector.create_transfer_from_notification.assert_called_once_with(
+        transaction_data, 9, "Revolut"
+    )
+    ctx.reply.assert_awaited_once_with(
+        "Created transfer: **Pekao** → **Revolut**\n12.34 PLN · 2026-08-02"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transfer_accepts_a_case_insensitive_account_name(handler):
+    channel = AsyncMock(spec=discord.TextChannel)
+    channel.id = 1
+    handler.channel = channel
+    source_message = AsyncMock(spec=discord.Message)
+    source_message.id = 9
+    source_message.channel = channel
+    source_message.reactions = [MagicMock(emoji="✅", me=True)]
+    channel.fetch_message.return_value = source_message
+    transaction_data = ActualTransactionData(
+        date=date(2026, 8, 2),
+        account="Pekao",
+        amount=Decimal("12.34"),
+        imported_payee="Transfer",
+        notes="Discord notification: 9",
+    )
+    handler.actual_connector.list_import_accounts.return_value = (
+        ImportableActualAccount("Pekao", False),
+        ImportableActualAccount("Revolut", False),
+        ImportableActualAccount("Savings", False),
+    )
+    handler.actual_connector.create_transfer_from_notification.return_value = (
+        TransferCreationStatus.CREATED
+    )
+    ctx = AsyncMock()
+    ctx.channel = channel
+    ctx.message.reference = MagicMock(message_id=9, channel_id=1)
+
+    with patch.object(
+        handler, "_transaction_data_from_message", return_value=transaction_data
+    ):
+        await handler.make_transfer(ctx, "revolut")
+
+    handler.actual_connector.create_transfer_from_notification.assert_called_once_with(
+        transaction_data, 9, "Revolut"
+    )
+    ctx.reply.assert_awaited_once_with(
+        "Created transfer: **Revolut** → **Pekao**\n12.34 PLN · 2026-08-02"
+    )


### PR DESCRIPTION
## What changed

- Add `!transfer [account name]` for replies to successfully imported bank notifications.
- Automatically select the other Actual account when exactly two are open; otherwise require an explicit, case-insensitive account name.
- Replace the tagged notification transaction with Actual’s linked transfer rows and tombstone the original transaction atomically.
- Make repeated commands idempotent and cover the workflow with unit and Actual integration tests.

## Why

Bank transfers such as Pekao → Revolut were imported as ordinary transactions, leaving the account balances unlinked in Actual.

## Validation

- `poetry run tox` (238 unit tests)
- `ACTUAL_TEST_URL=http://localhost:12013 pytest tests/integration_tests/test_actual_connector.py -q` (4 tests)